### PR TITLE
LNK-BE-4 유저 도메인 작업 및 전역 예외 & 응답 추상화

### DIFF
--- a/src/main/java/leets/leenk/domain/user/application/dto/response/UserInfoResponse.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/response/UserInfoResponse.java
@@ -1,0 +1,18 @@
+package leets.leenk.domain.user.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record UserInfoResponse(
+        long id,
+        String name,
+        int cardinal,
+        String profileImage,
+        String kakaoTalkId,
+        String introduction,
+        String mbti,
+        long totalReactionCount
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package leets.leenk.domain.user.application.exception;
+
+
+import leets.leenk.global.common.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+
+    USER_NOT_FOUND(2100, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/leenk/domain/user/application/mapper/UserMapper.java
@@ -1,0 +1,23 @@
+package leets.leenk.domain.user.application.mapper;
+
+import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public UserInfoResponse toUserInfoResponse(User user) {
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .cardinal(user.getCardinal())
+                .profileImage(user.getProfileImage())
+                .introduction(user.getIntroduction())
+                .kakaoTalkId(user.getKakaoTalkId())
+                .introduction(user.getIntroduction())
+                .mbti(user.getMbti())
+                .totalReactionCount(user.getTotalReactionCount())
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -1,0 +1,23 @@
+package leets.leenk.domain.user.application.usecase;
+
+import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
+import leets.leenk.domain.user.application.mapper.UserMapper;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.service.UserGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserUsecase {
+
+    private final UserMapper userMapper;
+    private final UserGetService userGetService;
+
+    public UserInfoResponse getUserInfo(long userId) {
+        User findUser = userGetService.findById(userId);
+
+        return userMapper.toUserInfoResponse(findUser);
+    }
+
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -6,6 +6,7 @@ import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,10 +15,10 @@ public class UserUsecase {
     private final UserMapper userMapper;
     private final UserGetService userGetService;
 
+    @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(long userId) {
         User findUser = userGetService.findById(userId);
 
         return userMapper.toUserInfoResponse(findUser);
     }
-
 }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -1,0 +1,51 @@
+package leets.leenk.domain.user.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.Size;
+import leets.leenk.global.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@SuperBuilder
+@Table(name="users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id")
+    private Long id;
+
+    @Size(max = 10)
+    @Column(length = 10, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int cardinal;
+
+    private String profileImage;
+
+    @Size(max = 4)
+    @Column(length = 4)
+    private String mbti;
+
+    @Size(max = 60)
+    @Column(length = 60)
+    private String introduction;
+
+    private String fcmToken;
+
+    @Size(max = 20)
+    @Column(length = 20)
+    private String kakaoTalkId;
+
+    private LocalDateTime deleteDate;
+}

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -47,5 +47,8 @@ public class User extends BaseEntity {
     @Column(length = 20)
     private String kakaoTalkId;
 
+    @Column(nullable = false)
+    private long totalReactionCount;
+
     private LocalDateTime deleteDate;
 }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
@@ -16,7 +16,7 @@ import org.hibernate.annotations.DynamicUpdate;
 public class UserSetting extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, columnDefinition = "boolean default true")

--- a/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
@@ -1,0 +1,35 @@
+package leets.leenk.domain.user.domain.entity;
+
+import jakarta.persistence.*;
+import leets.leenk.global.common.entity.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSetting extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(nullable = false, columnDefinition = "boolean default true")
+    private boolean isNewLeenkNotify;
+
+    @Column(nullable = false, columnDefinition = "boolean default true")
+    private boolean isLeenkStatusNotify;
+
+    @Column(nullable = false, columnDefinition = "boolean default true")
+    private boolean isNewFeedNotify;
+
+    @Column(nullable = false, columnDefinition = "boolean default true")
+    private boolean isNewReactionNotify;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+}

--- a/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
@@ -6,10 +6,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Getter
 @Entity
 @SuperBuilder
+@DynamicUpdate
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSetting extends BaseEntity {
 

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package leets.leenk.domain.user.domain.repository;
+
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.user.domain.service;
+
+import leets.leenk.domain.user.application.exception.UserNotFoundException;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserGetService {
+
+    private final UserRepository userRepository;
+
+    public User findById(long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -1,0 +1,18 @@
+package leets.leenk.domain.user.presentation;
+
+import leets.leenk.global.common.response.ResponseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode implements ResponseCodeInterface {
+
+    GET_MY_INFO(1100, HttpStatus.OK, "내 정보 조회에 성공했습니다."),
+    GET_USER_INFO(1101, HttpStatus.OK, "다른 사용자 정보 조회에 성공했습니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -1,0 +1,40 @@
+package leets.leenk.domain.user.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
+import leets.leenk.domain.user.application.usecase.UserUsecase;
+import leets.leenk.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static leets.leenk.domain.user.presentation.ResponseCode.GET_MY_INFO;
+import static leets.leenk.domain.user.presentation.ResponseCode.GET_USER_INFO;
+
+@Tag(name = "USER")
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserUsecase userUsecase;
+
+    @GetMapping
+    @Operation(summary = "마이페이지 조회 API")
+    public CommonResponse<UserInfoResponse> getMyInfo() {
+        UserInfoResponse response = userUsecase.getUserInfo(1L);
+
+        return CommonResponse.success(GET_MY_INFO, response);
+    }
+
+    @GetMapping("/{userId}")
+    @Operation(summary = "다른 사람 페이지 조회 API")
+    public CommonResponse<UserInfoResponse> getUserInfo(@PathVariable long userId) {
+        UserInfoResponse response = userUsecase.getUserInfo(userId);
+
+        return CommonResponse.success(GET_USER_INFO, response);
+    }
+}

--- a/src/main/java/leets/leenk/global/common/exception/BaseException.java
+++ b/src/main/java/leets/leenk/global/common/exception/BaseException.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 
 @Getter
 public abstract class BaseException extends RuntimeException {
-    private final ErrorCode errorCode;
+    private final ErrorCodeInterface errorCode;
 
-    public BaseException(final ErrorCode errorCode) {
+    public BaseException(final ErrorCodeInterface errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }

--- a/src/main/java/leets/leenk/global/common/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/common/exception/ErrorCode.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorCode {
+public enum ErrorCode implements ErrorCodeInterface{
     // 3000번대: 서버 에러
     INTERNAL_SERVER_ERROR    (3001, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
 

--- a/src/main/java/leets/leenk/global/common/exception/ErrorCodeInterface.java
+++ b/src/main/java/leets/leenk/global/common/exception/ErrorCodeInterface.java
@@ -1,0 +1,9 @@
+package leets.leenk.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCodeInterface {
+    int getCode();
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,7 @@
 package leets.leenk.global.common.exception;
 
-import java.util.List;
-import leets.leenk.global.common.response.CommonResponse;
 import leets.leenk.global.common.exception.response.ValidErrorResponse;
+import leets.leenk.global.common.response.CommonResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -11,12 +10,14 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import java.util.List;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<CommonResponse<Void>> handleException(BaseException e) {
-        ErrorCode errorCode = e.getErrorCode();
+        ErrorCodeInterface errorCode = e.getErrorCode();
         CommonResponse<Void> body = CommonResponse.error(errorCode);
 
         return ResponseEntity
@@ -77,7 +78,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
         Throwable cause = ex.getMostSpecificCause();
         if (cause instanceof BaseException be) {
-            ErrorCode errorCode = be.getErrorCode();
+            ErrorCodeInterface errorCode = be.getErrorCode();
             CommonResponse<Void> body = CommonResponse.error(errorCode);
 
             return ResponseEntity

--- a/src/main/java/leets/leenk/global/common/response/CommonResponse.java
+++ b/src/main/java/leets/leenk/global/common/response/CommonResponse.java
@@ -1,6 +1,6 @@
 package leets.leenk.global.common.response;
 
-import leets.leenk.global.common.exception.ErrorCode;
+import leets.leenk.global.common.exception.ErrorCodeInterface;
 
 public record CommonResponse<T> (
         int code,
@@ -8,28 +8,28 @@ public record CommonResponse<T> (
         T data
 )
 {
-    public static CommonResponse<Void> success(String message) {
+    public static CommonResponse<Void> success(ResponseCodeInterface responseCode) {
         return new CommonResponse<>(
-                200,
-                message,
+                responseCode.getCode(),
+                responseCode.getMessage(),
                 null
         );
     }
-    public static <T> CommonResponse<T> success(String message, T data) {
+    public static <T> CommonResponse<T> success(ResponseCodeInterface responseCode, T data) {
         return new CommonResponse<>(
-                200,
-                message,
+                responseCode.getCode(),
+                responseCode.getMessage(),
                 data
         );
     }
-    public static CommonResponse<Void> error(ErrorCode errorCode) {
+    public static CommonResponse<Void> error(ErrorCodeInterface errorCode) {
         return new CommonResponse<>(
                 errorCode.getCode(),
                 errorCode.getMessage(),
                 null
         );
     }
-    public static <T> CommonResponse<T> error(ErrorCode errorCode, T data) {
+    public static <T> CommonResponse<T> error(ErrorCodeInterface errorCode, T data) {
         return new CommonResponse<>(
                 errorCode.getCode(),
                 errorCode.getMessage(),

--- a/src/main/java/leets/leenk/global/common/response/ResponseCodeInterface.java
+++ b/src/main/java/leets/leenk/global/common/response/ResponseCodeInterface.java
@@ -1,0 +1,9 @@
+package leets.leenk.global.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResponseCodeInterface {
+    int getCode();
+    HttpStatus getStatus();
+    String getMessage();
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #8 

## 작업 내용 💻

- 유저와 유저 세팅 엔티티 작업 했습니다
- 예외와 응답시 인터페이스를 구현해서 추상화했습니다
- 유저 id의 경우 인증 서버의 weeth 계정 id로 저장하기 때문에 id 생성 전략을 작성하지 않았습니다


## 스크린샷 📷
- 정보 조회 시 (null인 값들은 자동으로 제거됨)
<img width="369" alt="image" src="https://github.com/user-attachments/assets/6abdf9e7-497c-4dff-9405-3d2bd627f204" />

- 없는 유저 조회 시
<img width="478" alt="image" src="https://github.com/user-attachments/assets/874485d0-01af-467b-b669-f0c8a15e90a1" />



## 같이 얘기해보고 싶은 내용이 있다면 작성 📢
- GlobalExceptionHandler에서 추상화가 필요한 부분만 ErrorCodeInterface로 수정하고, 나머지는 구현체로 유지했는데 어떤 방식이 조을까요??

