### PR TITLE
LNK-BE-3 인증서버 연동 1. 로그인 2. 회원가입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'

--- a/src/main/java/leets/leenk/domain/user/application/exception/UserInActiveException.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/UserInActiveException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class UserInActiveException extends BaseException {
+    public UserInActiveException(String message) {
+        super(ErrorCode.USER_IN_ACTIVE, message);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/exception/UserNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/UserNotFoundException.java
@@ -6,4 +6,8 @@ public class UserNotFoundException extends BaseException {
     public UserNotFoundException() {
         super(ErrorCode.USER_NOT_FOUND);
     }
+
+    public UserNotFoundException(String message) {
+        super(ErrorCode.USER_NOT_FOUND, message);
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/leenk/domain/user/application/mapper/UserMapper.java
@@ -2,6 +2,7 @@ package leets.leenk.domain.user.application.mapper;
 
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.global.auth.application.dto.response.OauthUserInfoResponse;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -18,6 +19,14 @@ public class UserMapper {
                 .introduction(user.getIntroduction())
                 .mbti(user.getMbti())
                 .totalReactionCount(user.getTotalReactionCount())
+                .build();
+    }
+
+    public User toUser(OauthUserInfoResponse oauthUserInfoResponse) {
+        return User.builder()
+                .id(oauthUserInfoResponse.userId())
+                .name(oauthUserInfoResponse.name())
+                .cardinal(oauthUserInfoResponse.cardinal())
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/user/application/mapper/UserSettingMapper.java
+++ b/src/main/java/leets/leenk/domain/user/application/mapper/UserSettingMapper.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.user.application.mapper;
+
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserSetting;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserSettingMapper {
+
+    public UserSetting toDefaultSetting(User user) {
+        return UserSetting.builder()
+                .isNewLeenkNotify(true)
+                .isLeenkStatusNotify(true)
+                .isNewFeedNotify(true)
+                .isNewReactionNotify(true)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserSettingRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserSettingRepository.java
@@ -1,0 +1,7 @@
+package leets.leenk.domain.user.domain.repository;
+
+import leets.leenk.domain.user.domain.entity.UserSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
@@ -6,6 +6,8 @@ import leets.leenk.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class UserGetService {
@@ -15,5 +17,9 @@ public class UserGetService {
     public User findById(long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    public Optional<User> existById(long userId) {
+        return userRepository.findById(userId);
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserSaveService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserSaveService.java
@@ -1,0 +1,16 @@
+package leets.leenk.domain.user.domain.service;
+
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSaveService {
+    private final UserRepository userRepository;
+
+    public void save(User user) {
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserSettingSaveService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserSettingSaveService.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.user.domain.service;
+
+import leets.leenk.domain.user.domain.entity.UserSetting;
+import leets.leenk.domain.user.domain.repository.UserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSettingSaveService {
+
+    private final UserSettingRepository userSettingRepository;
+
+    public void save(UserSetting userSetting) {
+        userSettingRepository.save(userSetting);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/request/KakaoAccessToken.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/request/KakaoAccessToken.java
@@ -1,0 +1,9 @@
+package leets.leenk.global.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoAccessToken(
+        @NotBlank
+        String kakaoAccessToken
+) {
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/request/KakaoAccessTokenRequest.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/request/KakaoAccessTokenRequest.java
@@ -2,7 +2,7 @@ package leets.leenk.global.auth.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record KakaoAccessToken(
+public record KakaoAccessTokenRequest(
         @NotBlank
         String kakaoAccessToken
 ) {

--- a/src/main/java/leets/leenk/global/auth/application/dto/response/LoginResponse.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/response/LoginResponse.java
@@ -1,0 +1,15 @@
+package leets.leenk.global.auth.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LoginResponse(
+        Long userId,
+        String name,
+        Integer cardinal,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/response/OauthErrorResponse.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/response/OauthErrorResponse.java
@@ -1,0 +1,7 @@
+package leets.leenk.global.auth.application.dto.response;
+
+public record OauthErrorResponse(
+        String error,
+        String error_description
+) {
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/response/OauthTokenResponse.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/response/OauthTokenResponse.java
@@ -1,0 +1,10 @@
+package leets.leenk.global.auth.application.dto.response;
+
+public record OauthTokenResponse(
+        String access_token,
+        String refresh_token,
+        String id_token,
+        String token_type,
+        Integer expires_in
+) {
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/response/OauthUserInfoResponse.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/response/OauthUserInfoResponse.java
@@ -1,0 +1,10 @@
+package leets.leenk.global.auth.application.dto.response;
+
+public record OauthUserInfoResponse(
+        long userId,
+        String name,
+        String email,
+        String tel,
+        int cardinal
+) {
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/response/OauthUserInfoResponse.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/response/OauthUserInfoResponse.java
@@ -3,8 +3,6 @@ package leets.leenk.global.auth.application.dto.response;
 public record OauthUserInfoResponse(
         long userId,
         String name,
-        String email,
-        String tel,
         int cardinal
 ) {
 }

--- a/src/main/java/leets/leenk/global/auth/application/exception/CustomJsonProcessingException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/CustomJsonProcessingException.java
@@ -1,9 +1,10 @@
 package leets.leenk.global.auth.application.exception;
 
 import leets.leenk.global.common.exception.BaseException;
+import leets.leenk.global.common.exception.ErrorCode;
 
 public class CustomJsonProcessingException extends BaseException {
     public CustomJsonProcessingException(String message) {
-        super(ErrorCode.JSON_PROCESSING, ErrorCode.JSON_PROCESSING.getMessage() + message);
+        super(ErrorCode.JSON_PROCESSING, ErrorCode.JSON_PROCESSING.getMessage() + " " + message);
     }
 }

--- a/src/main/java/leets/leenk/global/auth/application/exception/CustomJsonProcessingException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/CustomJsonProcessingException.java
@@ -1,0 +1,9 @@
+package leets.leenk.global.auth.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class CustomJsonProcessingException extends BaseException {
+    public CustomJsonProcessingException(String message) {
+        super(ErrorCode.JSON_PROCESSING, ErrorCode.JSON_PROCESSING.getMessage() + message);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements ErrorCodeInterface {
 
     OAUTH_ERROR(2001, HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    UN_REGISTER(2002, HttpStatus.UNAUTHORIZED, "가입되지 않은 사용자입니다."),
     USER_IN_ACTIVE(2000, HttpStatus.FORBIDDEN, "가입 승인이 허가되지 않은 계정입니다.");
 
     private final int code;

--- a/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
@@ -9,10 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
 
-    OAUTH_ERROR(2001, HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
-    UN_REGISTER(2002, HttpStatus.UNAUTHORIZED, "가입되지 않은 사용자입니다."),
     USER_IN_ACTIVE(2000, HttpStatus.FORBIDDEN, "가입 승인이 허가되지 않은 계정입니다."),
-    JSON_PROCESSING(3000, HttpStatus.INTERNAL_SERVER_ERROR, "Json 처리 중 문제가 발생했습니다.");
+    OAUTH_ERROR(2001, HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    UN_REGISTER(2002, HttpStatus.UNAUTHORIZED, "가입되지 않은 사용자입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 
     OAUTH_ERROR(2001, HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
     UN_REGISTER(2002, HttpStatus.UNAUTHORIZED, "가입되지 않은 사용자입니다."),
-    USER_IN_ACTIVE(2000, HttpStatus.FORBIDDEN, "가입 승인이 허가되지 않은 계정입니다.");
+    USER_IN_ACTIVE(2000, HttpStatus.FORBIDDEN, "가입 승인이 허가되지 않은 계정입니다."),
+    JSON_PROCESSING(3000, HttpStatus.INTERNAL_SERVER_ERROR, "Json 처리 중 문제가 발생했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package leets.leenk.global.auth.application.exception;
+
+import leets.leenk.global.common.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+
+    OAUTH_ERROR(2001, HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
+    USER_IN_ACTIVE(2000, HttpStatus.FORBIDDEN, "가입 승인이 허가되지 않은 계정입니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/global/auth/application/exception/OauthException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/OauthException.java
@@ -3,7 +3,7 @@ package leets.leenk.global.auth.application.exception;
 import leets.leenk.global.common.exception.BaseException;
 
 public class OauthException extends BaseException {
-    public OauthException() {
-        super(ErrorCode.OAUTH_ERROR);
+    public OauthException(String message) {
+        super(ErrorCode.OAUTH_ERROR, message);
     }
 }

--- a/src/main/java/leets/leenk/global/auth/application/exception/OauthException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/OauthException.java
@@ -1,0 +1,9 @@
+package leets.leenk.global.auth.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class OauthException extends BaseException {
+    public OauthException() {
+        super(ErrorCode.OAUTH_ERROR);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/exception/UnRegisterUserException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/UnRegisterUserException.java
@@ -1,0 +1,9 @@
+package leets.leenk.global.auth.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class UnRegisterUserException extends BaseException {
+    public UnRegisterUserException() {
+        super(ErrorCode.UN_REGISTER);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/exception/UserInActiveException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/UserInActiveException.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.user.application.exception;
+package leets.leenk.global.auth.application.exception;
 
 import leets.leenk.global.common.exception.BaseException;
 

--- a/src/main/java/leets/leenk/global/auth/application/mapper/LoginMapper.java
+++ b/src/main/java/leets/leenk/global/auth/application/mapper/LoginMapper.java
@@ -1,0 +1,26 @@
+package leets.leenk.global.auth.application.mapper;
+
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.global.auth.application.dto.response.LoginResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoginMapper {
+
+    public LoginResponse toLoginResponse(String accessToken, String refreshToken) {
+        return LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public LoginResponse toLoginResponse(User user, String accessToken, String refreshToken) {
+        return LoginResponse.builder()
+                .userId(user.getId())
+                .name(user.getName())
+                .cardinal(user.getCardinal())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/property/KakaoOauthProperty.java
+++ b/src/main/java/leets/leenk/global/auth/application/property/KakaoOauthProperty.java
@@ -1,0 +1,15 @@
+package leets.leenk.global.auth.application.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "auth.oauth2.kakao")
+public class KakaoOauthProperty {
+    private String kakaoGrantType;
+    private String kakaoGrantTypeName;
+}

--- a/src/main/java/leets/leenk/global/auth/application/property/OauthProperty.java
+++ b/src/main/java/leets/leenk/global/auth/application/property/OauthProperty.java
@@ -1,0 +1,19 @@
+package leets.leenk.global.auth.application.property;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "auth.oauth2")
+public class OauthProperty {
+    private String clientId;
+    private String clientSecret;
+    private String oauthIss;
+    private String oauthServerTokenUri;
+    private String oauthJwkSetUri;
+    private String oauthServerUserInfoUri;
+}

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -1,0 +1,58 @@
+package leets.leenk.global.auth.application.usecase;
+
+import leets.leenk.domain.user.application.mapper.UserMapper;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.service.UserGetService;
+import leets.leenk.domain.user.domain.service.UserSaveService;
+import leets.leenk.global.auth.application.dto.request.KakaoAccessToken;
+import leets.leenk.global.auth.application.dto.response.LoginResponse;
+import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;
+import leets.leenk.global.auth.application.dto.response.OauthUserInfoResponse;
+import leets.leenk.global.auth.application.mapper.LoginMapper;
+import leets.leenk.global.auth.domain.service.KakaoOauthApiService;
+import leets.leenk.global.auth.domain.service.OauthApiService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthUsecase {
+    private final UserGetService userGetService;
+    private final UserSaveService userSaveService;
+    private final KakaoOauthApiService kakaoOauthApiService;
+    private final OauthApiService oauthApiService;
+    private final JwtDecoder jwtDecoder;
+    private final LoginMapper loginMapper;
+    private final UserMapper userMapper;
+
+    @Transactional
+    public LoginResponse kakaoLogin(KakaoAccessToken kakaoAccessToken) {
+        OauthTokenResponse response = kakaoOauthApiService.getOauthToken(kakaoAccessToken.kakaoAccessToken());
+        String idToken = response.id_token();
+        Jwt jwt = jwtDecoder.decode(idToken);
+
+        long userId = Long.parseLong(jwt.getClaimAsString("id"));
+
+        Optional<User> optionalUser = userGetService.existById(userId);
+
+        if (optionalUser.isEmpty()) {
+            // 인증 서버 유저 정보 조회
+            OauthUserInfoResponse userInfo = oauthApiService.getUserInfo(response.access_token());
+            // 회원가입
+            User user = userMapper.toUser(userInfo);
+            userSaveService.save(user);
+            // return 유저 정보 및 임시 토큰
+            return loginMapper.toLoginResponse(user, response.access_token(), response.refresh_token());
+        }
+
+        User user = optionalUser.get();
+        return loginMapper.toLoginResponse(response.access_token(), response.refresh_token());
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -1,9 +1,12 @@
 package leets.leenk.global.auth.application.usecase;
 
 import leets.leenk.domain.user.application.mapper.UserMapper;
+import leets.leenk.domain.user.application.mapper.UserSettingMapper;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserSetting;
 import leets.leenk.domain.user.domain.service.UserGetService;
 import leets.leenk.domain.user.domain.service.UserSaveService;
+import leets.leenk.domain.user.domain.service.UserSettingSaveService;
 import leets.leenk.global.auth.application.dto.request.KakaoAccessTokenRequest;
 import leets.leenk.global.auth.application.dto.response.LoginResponse;
 import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;
@@ -26,10 +29,12 @@ public class AuthUsecase {
 
     private final UserGetService userGetService;
     private final UserSaveService userSaveService;
+    private final UserSettingSaveService userSettingSaveService;
     private final KakaoOauthApiService kakaoOauthApiService;
     private final OauthApiService oauthApiService;
     private final LoginMapper loginMapper;
     private final UserMapper userMapper;
+    private final UserSettingMapper userSettingMapper;
 
     private final JwtDecoder jwtDecoder;
 
@@ -57,7 +62,10 @@ public class AuthUsecase {
     private LoginResponse saveNewUser(OauthTokenResponse response) {
         OauthUserInfoResponse userInfo = oauthApiService.getUserInfo(response.access_token());
         User user = userMapper.toUser(userInfo);
+        UserSetting userSetting = userSettingMapper.toDefaultSetting(user);
+
         userSaveService.save(user);
+        userSettingSaveService.save(userSetting);
 
         return loginMapper.toLoginResponse(user, response.access_token(), response.refresh_token());
     }

--- a/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
@@ -1,11 +1,11 @@
 package leets.leenk.global.auth.domain.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import leets.leenk.global.auth.application.exception.UserInActiveException;
-import leets.leenk.domain.user.application.exception.UserNotFoundException;
 import leets.leenk.global.auth.application.dto.response.OauthErrorResponse;
 import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;
 import leets.leenk.global.auth.application.exception.OauthException;
+import leets.leenk.global.auth.application.exception.UnRegisterUserException;
+import leets.leenk.global.auth.application.exception.UserInActiveException;
 import leets.leenk.global.auth.application.property.KakaoOauthProperty;
 import leets.leenk.global.auth.application.property.OauthProperty;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class KakaoOauthApiService {
 
                     switch (error.error()) {
                         case "WAE-001" -> throw new UserInActiveException(error.error_description());
-                        case "WAE-002" -> throw new UserNotFoundException(error.error_description());
+                        case "WAE-002" -> throw new UnRegisterUserException();
                         default -> throw new OauthException(error.error_description());
                     }
                 })

--- a/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
@@ -19,6 +19,9 @@ import org.springframework.web.client.RestClient;
 @Service
 @RequiredArgsConstructor
 public class KakaoOauthApiService {
+    private static final String USER_INACTIVE_ERROR = "WAE-001";
+    private static final String USER_NOT_FOUND_ERROR = "WAE-002";
+
     private final OauthProperty oauthProperty;
     private final KakaoOauthProperty kakaoOauthProperty;
 
@@ -41,8 +44,8 @@ public class KakaoOauthApiService {
                     OauthErrorResponse error = objectMapper.readValue(response.getBody(), OauthErrorResponse.class);
 
                     switch (error.error()) {
-                        case "WAE-001" -> throw new UserInActiveException(error.error_description());
-                        case "WAE-002" -> throw new UnRegisterUserException();
+                        case USER_INACTIVE_ERROR -> throw new UserInActiveException(error.error_description());
+                        case USER_NOT_FOUND_ERROR -> throw new UnRegisterUserException();
                         default -> throw new OauthException(error.error_description());
                     }
                 })

--- a/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
@@ -1,0 +1,51 @@
+package leets.leenk.global.auth.domain.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import leets.leenk.domain.user.application.exception.UserInActiveException;
+import leets.leenk.domain.user.application.exception.UserNotFoundException;
+import leets.leenk.global.auth.application.dto.response.OauthErrorResponse;
+import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;
+import leets.leenk.global.auth.application.exception.OauthException;
+import leets.leenk.global.auth.application.property.KakaoOauthProperty;
+import leets.leenk.global.auth.application.property.OauthProperty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthApiService {
+    private final OauthProperty oauthProperty;
+    private final KakaoOauthProperty kakaoOauthProperty;
+
+    private final RestClient authRestClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OauthTokenResponse getOauthToken(String kakaoAccessToken) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", kakaoOauthProperty.getKakaoGrantType());
+        body.add("client_id", oauthProperty.getClientId());
+        body.add("client_secret", oauthProperty.getClientSecret());
+        body.add(kakaoOauthProperty.getKakaoGrantTypeName(), kakaoAccessToken);
+
+        return authRestClient.post()
+                .uri(oauthProperty.getOauthServerTokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, (request, response) -> {
+                    OauthErrorResponse error = objectMapper.readValue(response.getBody(), OauthErrorResponse.class);
+
+                    switch (error.error()) {
+                        case "WAE-001" -> throw new UserInActiveException(error.error_description());
+                        case "WAE-002" -> throw new UserNotFoundException(error.error_description());
+                        default -> throw new OauthException();
+                    }
+                })
+                .body(OauthTokenResponse.class);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
@@ -1,7 +1,7 @@
 package leets.leenk.global.auth.domain.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import leets.leenk.domain.user.application.exception.UserInActiveException;
+import leets.leenk.global.auth.application.exception.UserInActiveException;
 import leets.leenk.domain.user.application.exception.UserNotFoundException;
 import leets.leenk.global.auth.application.dto.response.OauthErrorResponse;
 import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;

--- a/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
@@ -43,7 +43,7 @@ public class KakaoOauthApiService {
                     switch (error.error()) {
                         case "WAE-001" -> throw new UserInActiveException(error.error_description());
                         case "WAE-002" -> throw new UserNotFoundException(error.error_description());
-                        default -> throw new OauthException();
+                        default -> throw new OauthException(error.error_description());
                     }
                 })
                 .body(OauthTokenResponse.class);

--- a/src/main/java/leets/leenk/global/auth/domain/service/OauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/OauthApiService.java
@@ -1,0 +1,23 @@
+package leets.leenk.global.auth.domain.service;
+
+import leets.leenk.global.auth.application.dto.response.OauthUserInfoResponse;
+import leets.leenk.global.auth.application.property.OauthProperty;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+@RequiredArgsConstructor
+public class OauthApiService {
+
+    private final OauthProperty oauthProperty;
+    private final RestClient authRestClient;
+
+    public OauthUserInfoResponse getUserInfo(String accessToken) {
+        return authRestClient.get()
+                .uri(oauthProperty.getOauthServerUserInfoUri())
+                .header("Authorization", "Bearer " + accessToken)
+                .retrieve()
+                .body(OauthUserInfoResponse.class);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
@@ -1,8 +1,9 @@
 package leets.leenk.global.auth.presentation.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import leets.leenk.global.auth.application.dto.request.KakaoAccessToken;
+import leets.leenk.global.auth.application.dto.request.KakaoAccessTokenRequest;
 import leets.leenk.global.auth.application.dto.response.LoginResponse;
 import leets.leenk.global.auth.application.usecase.AuthUsecase;
 import leets.leenk.global.common.response.CommonResponse;
@@ -18,8 +19,9 @@ public class AuthController {
     private final AuthUsecase authUsecase;
 
     @PostMapping("/kakao/login")
-    public CommonResponse<LoginResponse> kakaoLogin(@RequestBody @Valid KakaoAccessToken kakaoAccessToken) {
-        LoginResponse response = authUsecase.kakaoLogin(kakaoAccessToken);
+    @Operation(summary = "카카오 login api [for mobile]")
+    public CommonResponse<LoginResponse> kakaoLogin(@RequestBody @Valid KakaoAccessTokenRequest kakaoAccessTokenRequest) {
+        LoginResponse response = authUsecase.kakaoLogin(kakaoAccessTokenRequest);
         
         return CommonResponse.success(ResponseCode.LOGIN_SUCCESS, response);
     }

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
@@ -1,0 +1,26 @@
+package leets.leenk.global.auth.presentation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import leets.leenk.global.auth.application.dto.request.KakaoAccessToken;
+import leets.leenk.global.auth.application.dto.response.LoginResponse;
+import leets.leenk.global.auth.application.usecase.AuthUsecase;
+import leets.leenk.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "AUTH")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthUsecase authUsecase;
+
+    @PostMapping("/kakao/login")
+    public CommonResponse<LoginResponse> kakaoLogin(@RequestBody @Valid KakaoAccessToken kakaoAccessToken) {
+        LoginResponse response = authUsecase.kakaoLogin(kakaoAccessToken);
+        
+        return CommonResponse.success(ResponseCode.LOGIN_SUCCESS, response);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
@@ -22,7 +22,11 @@ public class AuthController {
     @Operation(summary = "카카오 login api [for mobile]")
     public CommonResponse<LoginResponse> kakaoLogin(@RequestBody @Valid KakaoAccessTokenRequest kakaoAccessTokenRequest) {
         LoginResponse response = authUsecase.kakaoLogin(kakaoAccessTokenRequest);
-        
-        return CommonResponse.success(ResponseCode.LOGIN_SUCCESS, response);
+
+        if (response.userId() == null) {
+            return CommonResponse.success(ResponseCode.LOGIN_SUCCESS, response);
+        }
+
+        return CommonResponse.success(ResponseCode.INITIAL_LOGIN_SUCCESS, response);
     }
 }

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/ResponseCode.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/ResponseCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ResponseCode implements ResponseCodeInterface {
 
-    LOGIN_SUCCESS(1003, HttpStatus.OK, "로그인에 성공했습니다.");
+    LOGIN_SUCCESS(1003, HttpStatus.OK, "로그인에 성공했습니다."),
+    INITIAL_LOGIN_SUCCESS(1002, HttpStatus.OK, "최초 로그인에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/ResponseCode.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/ResponseCode.java
@@ -1,0 +1,17 @@
+package leets.leenk.global.auth.presentation.controller;
+
+import leets.leenk.global.common.response.ResponseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode implements ResponseCodeInterface {
+
+    LOGIN_SUCCESS(1003, HttpStatus.OK, "로그인에 성공했습니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/global/common/exception/BaseException.java
+++ b/src/main/java/leets/leenk/global/common/exception/BaseException.java
@@ -10,4 +10,9 @@ public abstract class BaseException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public BaseException(final ErrorCodeInterface errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/leets/leenk/global/common/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/common/exception/ErrorCode.java
@@ -6,15 +6,16 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ErrorCode implements ErrorCodeInterface{
+public enum ErrorCode implements ErrorCodeInterface {
     // 3000번대: 서버 에러
-    INTERNAL_SERVER_ERROR    (3001, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    INTERNAL_SERVER_ERROR(3001, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    JSON_PROCESSING(3002, HttpStatus.INTERNAL_SERVER_ERROR, "JSON 처리 중 문제가 발생했습니다."),
 
     // 4000번대: 클라이언트 요청 에러
-    INVALID_ARGUMENT         (4001, HttpStatus.BAD_REQUEST,"잘못된 인자입니다."),
-    JSON_PARSE_ERROR         (4002, HttpStatus.BAD_REQUEST, "잘못된 JSON 형식의 요청입니다."),
-    RESOURCE_NOT_FOUND       (4003, HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
-    METHOD_NOT_ALLOWED       (4004, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다.");
+    INVALID_ARGUMENT(4001, HttpStatus.BAD_REQUEST, "잘못된 인자입니다."),
+    JSON_PARSE_ERROR(4002, HttpStatus.BAD_REQUEST, "잘못된 JSON 형식의 요청입니다."),
+    RESOURCE_NOT_FOUND(4003, HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
+    METHOD_NOT_ALLOWED(4004, HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
@@ -18,7 +18,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<CommonResponse<Void>> handleException(BaseException e) {
         ErrorCodeInterface errorCode = e.getErrorCode();
-        CommonResponse<Void> body = CommonResponse.error(errorCode);
+        String errorMessage = e.getMessage();
+        CommonResponse<Void> body = CommonResponse.error(errorCode, errorMessage);
 
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
@@ -95,9 +95,9 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<CommonResponse<Void>> handleAll() {
+    public ResponseEntity<CommonResponse<Void>> handleAll(Exception e) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        CommonResponse<Void> body = CommonResponse.error(errorCode);
+        CommonResponse<Void> body = CommonResponse.error(errorCode, e.getMessage());
 
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/leets/leenk/global/common/response/CommonResponse.java
+++ b/src/main/java/leets/leenk/global/common/response/CommonResponse.java
@@ -29,6 +29,13 @@ public record CommonResponse<T> (
                 null
         );
     }
+    public static CommonResponse<Void> error(ErrorCodeInterface errorCode, String message) {
+        return new CommonResponse<>(
+                errorCode.getCode(),
+                message,
+                null
+        );
+    }
     public static <T> CommonResponse<T> error(ErrorCodeInterface errorCode, T data) {
         return new CommonResponse<>(
                 errorCode.getCode(),

--- a/src/main/java/leets/leenk/global/config/PermitUrlConfig.java
+++ b/src/main/java/leets/leenk/global/config/PermitUrlConfig.java
@@ -9,6 +9,7 @@ public class PermitUrlConfig {
                 "/v3/api-docs/**",
                 "/swagger-ui/**",
                 "/health-check",
+                "/kakao/login"
         };
     }
 }

--- a/src/main/java/leets/leenk/global/config/RestClientConfig.java
+++ b/src/main/java/leets/leenk/global/config/RestClientConfig.java
@@ -1,0 +1,13 @@
+package leets.leenk.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Bean
+    public RestClient authRestClient(RestClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,3 +11,16 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+
+auth:
+  oauth2:
+    clientId: ${CLIENT_ID}
+    clientSecret: ${CLIENT_SECRET}
+    oauthIss: ${OAUTH_ISS}
+    oauthServerTokenUri: ${OAUTH_SERVER_TOKEN_URI}
+    oauthJwkSetUri: ${OAUTH_JWK_SET_URI}
+    oauthServerUserInfoUri: ${OAUTH_SERVER_USER_INFO_URI}
+    kakao:
+      kakao_grant_type: ${KAKAO_GRANT_TYPE}
+      kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}
+

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -14,13 +14,12 @@ spring:
 
 auth:
   oauth2:
-    clientId: ${CLIENT_ID}
-    clientSecret: ${CLIENT_SECRET}
-    oauthIss: ${OAUTH_ISS}
-    oauthServerTokenUri: ${OAUTH_SERVER_TOKEN_URI}
-    oauthJwkSetUri: ${OAUTH_JWK_SET_URI}
-    oauthServerUserInfoUri: ${OAUTH_SERVER_USER_INFO_URI}
+    client-id: ${CLIENT_ID}
+    client-secret: ${CLIENT_SECRET}
+    oauth-iss: ${OAUTH_ISS}
+    oauth-server-token-uri: ${OAUTH_SERVER_TOKEN_URI}
+    oauth-jwk-set-uri: ${OAUTH_JWK_SET_URI}
+    oauth-server-user-info-uri: ${OAUTH_SERVER_USER_INFO_URI}
     kakao:
       kakao_grant_type: ${KAKAO_GRANT_TYPE}
       kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}
-

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -11,3 +11,15 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+
+auth:
+  oauth2:
+    clientId: ${CLIENT_ID}
+    clientSecret: ${CLIENT_SECRET}
+    oauthIss: ${OAUTH_ISS}
+    oauthServerTokenUri: ${OAUTH_SERVER_TOKEN_URI}
+    oauthJwkSetUri: ${OAUTH_JWK_SET_URI}
+    oauthServerUserInfoUri: ${OAUTH_SERVER_USER_INFO_URI}
+    kakao:
+     kakao_grant_type: ${KAKAO_GRANT_TYPE}
+     kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,12 +14,13 @@ spring:
 
 auth:
   oauth2:
-    clientId: ${CLIENT_ID}
-    clientSecret: ${CLIENT_SECRET}
-    oauthIss: ${OAUTH_ISS}
-    oauthServerTokenUri: ${OAUTH_SERVER_TOKEN_URI}
-    oauthJwkSetUri: ${OAUTH_JWK_SET_URI}
-    oauthServerUserInfoUri: ${OAUTH_SERVER_USER_INFO_URI}
+    client-id: ${CLIENT_ID}
+    client-secret: ${CLIENT_SECRET}
+    oauth-iss: ${OAUTH_ISS}
+    oauth-server-token-uri: ${OAUTH_SERVER_TOKEN_URI}
+    oauth-jwk-set-uri: ${OAUTH_JWK_SET_URI}
+    oauth-server-user-info-uri: ${OAUTH_SERVER_USER_INFO_URI}
     kakao:
-     kakao_grant_type: ${KAKAO_GRANT_TYPE}
-     kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}
+      kakao_grant_type: ${KAKAO_GRANT_TYPE}
+      kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}
+


### PR DESCRIPTION
## Related issue 🛠
- closed #7 

## 작업 내용 💻
- 인증 서버와 연동하여 로그인/회원가입 로직을 구현했습니다
- 일부 예외처리를 수정했습니다
- Spring Resource Server 라이브러리를 사용해 OIDC 프로토콜에 맞게 Id_token을 디코딩해서 Claim 내부 user_id 값을 빼와서 사용하고 있습니다 -> 이는 링크 DB의 유저 정보 및 유저 생성시 활용됩니다
-     전체 플로우: 카카오 SDK를 이용해 모바일에서 카카오 액세스 토큰을 받는다 -> 링크 서버를 통해 Weeth 인증 서버로 요청을 보낸다 -> 받아온 id_token을 검증해 user_id를 얻는다 -> DB를 조회해 로그인/회원가입을 진행하고 액세스 토큰과 리프레시 토큰을 발행한다

- 임시 회원가입이 없기 때문에 임시 토큰 발급은 생략했습니다
- 예외를 일반 예외 / 인증 예외로 분리해서 401, 403은 인증 예외로 처리하도록 분리했습니다. 기존 Weeth는 다 User 도메인에서 처리했으므로 차이가 있음을 인지해주세용
- 서버간 API 통신은 `RestClient`를 활용했고, 인증서버의 예외에 맞게 예외 처리도 진행했습니당

## 스크린샷 📷
- 로그인 성공
<img width="655" alt="image" src="https://github.com/user-attachments/assets/d26d6460-6d16-4b06-ae76-a831215662bb" />

- 최초 로그인 성공
<img width="422" alt="image" src="https://github.com/user-attachments/assets/fcc99f4f-9b0b-4209-a791-61d040db9617" />

- 카카오 액세스 토큰이 올바르지 않은 경우 (인증서버 예외 메시지를 보여줌)
<img width="596" alt="image" src="https://github.com/user-attachments/assets/3421d6e2-c793-472f-bf78-5b9643bcdb74" />

- Weeth 유저를 찾을 수 없는 경우 (가입하지 않은 경우 / 엣지 케이스로 kakaoId가 저장되지 않은 경우)
<img width="351" alt="image" src="https://github.com/user-attachments/assets/759c9deb-f41a-4385-91cf-820914ce0e89" />

- Weeth 가입 승인 되지 않은 경우
<img width="412" alt="image" src="https://github.com/user-attachments/assets/314e9f92-a1ab-4405-876e-fecfa88fa96a" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢
- 로그인 / 회원가입 플로우에 맞게 잘 구현되었는지 검토 부탁드립니다!
- 인증/권한 예외처리 및 인증 객체 설정은 다음 PR에 올릴 예정입니다
- 기본 정보 입력도 다음 PR에 구현하겠습니당



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 카카오 OAuth2를 통한 사용자 인증 및 로그인 기능이 추가되었습니다.
  - 카카오 로그인 엔드포인트(/kakao/login)가 제공됩니다.
  - OAuth2 리소스 서버 및 JWT 기반 인증이 적용되었습니다.
  - 사용자 및 사용자 설정의 기본 생성 및 저장 기능이 추가되었습니다.
  - 인증 및 사용자 관련 예외 및 응답 구조가 개선되었습니다.
  - 로그인 응답에 사용자 정보 및 토큰이 포함됩니다.
  - OAuth 토큰 및 사용자 정보 조회 서비스가 도입되었습니다.
  - 인증 관련 프로퍼티 및 설정 클래스가 추가되었습니다.
  - JWT 디코더 및 검증 로직이 강화되었습니다.

- **버그 수정**
  - 예외 발생 시 에러 메시지가 응답에 포함되도록 개선되었습니다.

- **설정**
  - OAuth2 및 카카오 관련 환경설정이 추가되었습니다.
  - 인증 관련 RestClient 및 보안 설정이 반영되었습니다.

- **문서화**
  - Swagger를 통한 인증 API 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->