### PR TITLE
LNK-BE-3 추가 구현

### DIFF
--- a/src/main/java/leets/leenk/domain/user/application/dto/request/IntroductionRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/IntroductionRequest.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record IntroductionRequest(
+        @Size(max = 200)
+        String introduction
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/KakaoTalkIdRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/KakaoTalkIdRequest.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record KakaoTalkIdRequest(
+        @Size(max = 20)
+        String kakaoTalkId
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/MbtiRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/MbtiRequest.java
@@ -1,0 +1,10 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MbtiRequest(
+        @Size(max = 4) @NotBlank
+        String mbti
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/MbtiRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/MbtiRequest.java
@@ -1,10 +1,9 @@
 package leets.leenk.domain.user.application.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record MbtiRequest(
-        @Size(max = 4) @NotBlank
+        @Size(max = 4)
         String mbti
 ) {
 }

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/ProfileImageRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/ProfileImageRequest.java
@@ -1,0 +1,6 @@
+package leets.leenk.domain.user.application.dto.request;
+
+public record ProfileImageRequest(
+        String profileImage
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/RegisterRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/RegisterRequest.java
@@ -1,0 +1,15 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+        @NotBlank
+        String kakaoTalkId,
+        @Size(max = 200)
+        String introduction,
+        String profileImage,
+        @Size(max = 4)
+        String mbti
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -1,8 +1,6 @@
 package leets.leenk.domain.user.application.usecase;
 
-import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
-import leets.leenk.domain.user.application.dto.request.MbtiRequest;
-import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
+import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.mapper.UserMapper;
 import leets.leenk.domain.user.domain.entity.User;
@@ -20,11 +18,25 @@ public class UserUsecase {
     private final UserGetService userGetService;
     private final UserUpdateService userUpdateService;
 
+    @Transactional
+    public void completeProfile(long userId, RegisterRequest request) {
+        User user = userGetService.findById(userId);
+
+        userUpdateService.completeProfile(user, request);
+    }
+
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(long userId) {
         User findUser = userGetService.findById(userId);
 
         return userMapper.toUserInfoResponse(findUser);
+    }
+
+    @Transactional
+    public void updateKakaoTalkId(long userId, KakaoTalkIdRequest request) {
+        User user = userGetService.findById(userId);
+
+        userUpdateService.updateKakaoTalkId(user, request.kakaoTalkId());
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -1,9 +1,13 @@
 package leets.leenk.domain.user.application.usecase;
 
+import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
+import leets.leenk.domain.user.application.dto.request.MbtiRequest;
+import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.mapper.UserMapper;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.service.UserGetService;
+import leets.leenk.domain.user.domain.service.UserUpdateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,11 +18,33 @@ public class UserUsecase {
 
     private final UserMapper userMapper;
     private final UserGetService userGetService;
+    private final UserUpdateService userUpdateService;
 
     @Transactional(readOnly = true)
     public UserInfoResponse getUserInfo(long userId) {
         User findUser = userGetService.findById(userId);
 
         return userMapper.toUserInfoResponse(findUser);
+    }
+
+    @Transactional
+    public void updateProfileImage(long userId, ProfileImageRequest request) {
+        User user = userGetService.findById(userId);
+
+        userUpdateService.updateProfileImage(user, request.profileImage());
+    }
+
+    @Transactional
+    public void updateIntroduction(long userId, IntroductionRequest request) {
+        User user = userGetService.findById(userId);
+
+        userUpdateService.updateIntroduction(user, request.introduction());
+    }
+
+    @Transactional
+    public void updateMbti(long userId, MbtiRequest request) {
+        User user = userGetService.findById(userId);
+
+        userUpdateService.updateMbti(user, request.mbti());
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -51,4 +51,16 @@ public class User extends BaseEntity {
     private long totalReactionCount;
 
     private LocalDateTime deleteDate;
+
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void updateIntroduction(String introduction) {
+        this.introduction = introduction;
+    }
+
+    public void updateMbti(String mbti) {
+        this.mbti = mbti;
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -52,6 +52,10 @@ public class User extends BaseEntity {
 
     private LocalDateTime deleteDate;
 
+    public void updateKakaoTalkId(String kakaoTalkId) {
+        this.kakaoTalkId = kakaoTalkId;
+    }
+
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
     }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -44,7 +44,7 @@ public class User extends BaseEntity {
     private String fcmToken;
 
     @Size(max = 20)
-    @Column(length = 20)
+    @Column(nullable = false, length = 20)
     private String kakaoTalkId;
 
     @Column(nullable = false)

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserUpdateService.java
@@ -1,10 +1,31 @@
 package leets.leenk.domain.user.domain.service;
 
+import leets.leenk.domain.user.application.dto.request.RegisterRequest;
 import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.stereotype.Service;
 
 @Service
 public class UserUpdateService {
+
+    public void completeProfile(User user, RegisterRequest request) {
+        user.updateKakaoTalkId(request.kakaoTalkId());
+
+        if (request.introduction() != null) {
+            user.updateIntroduction(request.introduction());
+        }
+
+        if (request.profileImage() != null) {
+            user.updateProfileImage(request.profileImage());
+        }
+
+        if (request.mbti() != null) {
+            user.updateMbti(request.mbti());
+        }
+    }
+
+    public void updateKakaoTalkId(User user, String kakaoTalkId) {
+        user.updateKakaoTalkId(kakaoTalkId);
+    }
 
     public void updateProfileImage(User user, String profileImage) {
         user.updateProfileImage(profileImage);

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserUpdateService.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.user.domain.service;
+
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserUpdateService {
+
+    public void updateProfileImage(User user, String profileImage) {
+        user.updateProfileImage(profileImage);
+    }
+
+    public void updateIntroduction(User user, String introduction) {
+        user.updateIntroduction(introduction);
+    }
+
+    public void updateMbti(User user, String mbti) {
+        user.updateMbti(mbti);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -9,11 +9,14 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ResponseCode implements ResponseCodeInterface {
 
+    COMPLETE_PROFILE(1001, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
+
     GET_MY_INFO(1100, HttpStatus.OK, "내 정보 조회에 성공했습니다."),
     GET_USER_INFO(1101, HttpStatus.OK, "다른 사용자 정보 조회에 성공했습니다."),
     UPDATE_PROFILE_IMAGE(1102, HttpStatus.OK, "프로필 이미지 수정에 성공했습니다."),
     UPDATE_INTRODUCTION(1103, HttpStatus.OK, "자기소개 수정에 성공했습니다."),
-    UPDATE_MBTI(1104, HttpStatus.OK, "MBTI 수정에 성공했습니다.");
+    UPDATE_MBTI(1104, HttpStatus.OK, "MBTI 수정에 성공했습니다."),
+    UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -9,14 +9,13 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ResponseCode implements ResponseCodeInterface {
 
-    COMPLETE_PROFILE(1001, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
-
     GET_MY_INFO(1100, HttpStatus.OK, "내 정보 조회에 성공했습니다."),
     GET_USER_INFO(1101, HttpStatus.OK, "다른 사용자 정보 조회에 성공했습니다."),
     UPDATE_PROFILE_IMAGE(1102, HttpStatus.OK, "프로필 이미지 수정에 성공했습니다."),
     UPDATE_INTRODUCTION(1103, HttpStatus.OK, "자기소개 수정에 성공했습니다."),
     UPDATE_MBTI(1104, HttpStatus.OK, "MBTI 수정에 성공했습니다."),
-    UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다.");
+    UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다."),
+    COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 public enum ResponseCode implements ResponseCodeInterface {
 
     GET_MY_INFO(1100, HttpStatus.OK, "내 정보 조회에 성공했습니다."),
-    GET_USER_INFO(1101, HttpStatus.OK, "다른 사용자 정보 조회에 성공했습니다.");
+    GET_USER_INFO(1101, HttpStatus.OK, "다른 사용자 정보 조회에 성공했습니다."),
+    UPDATE_PROFILE_IMAGE(1102, HttpStatus.OK, "프로필 이미지 수정에 성공했습니다."),
+    UPDATE_INTRODUCTION(1103, HttpStatus.OK, "자기소개 수정에 성공했습니다."),
+    UPDATE_MBTI(1104, HttpStatus.OK, "MBTI 수정에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -1,18 +1,20 @@
 package leets.leenk.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
+import leets.leenk.domain.user.application.dto.request.MbtiRequest;
+import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.usecase.UserUsecase;
+import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import static leets.leenk.domain.user.presentation.ResponseCode.GET_MY_INFO;
-import static leets.leenk.domain.user.presentation.ResponseCode.GET_USER_INFO;
+import static leets.leenk.domain.user.presentation.ResponseCode.*;
 
 @Tag(name = "USER")
 @RestController
@@ -24,8 +26,8 @@ public class UserController {
 
     @GetMapping
     @Operation(summary = "마이페이지 조회 API")
-    public CommonResponse<UserInfoResponse> getMyInfo() {
-        UserInfoResponse response = userUsecase.getUserInfo(1L);
+    public CommonResponse<UserInfoResponse> getMyInfo(@Parameter(hidden = true) @CurrentUserId Long userId) {
+        UserInfoResponse response = userUsecase.getUserInfo(userId);
 
         return CommonResponse.success(GET_MY_INFO, response);
     }
@@ -36,5 +38,32 @@ public class UserController {
         UserInfoResponse response = userUsecase.getUserInfo(userId);
 
         return CommonResponse.success(GET_USER_INFO, response);
+    }
+
+    @PatchMapping("/me/profile-image")
+    @Operation(summary = "내 정보 수정 - 프로필 사진")
+    public CommonResponse<Void> updateProfileImage(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                   @Valid @RequestBody ProfileImageRequest request) {
+        userUsecase.updateProfileImage(userId, request);
+
+        return CommonResponse.success(UPDATE_PROFILE_IMAGE);
+    }
+
+    @PatchMapping("/me/introduction")
+    @Operation(summary = "내 정보 수정 - 자기소개")
+    public CommonResponse<Void> updateIntroduction(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                   @Valid @RequestBody IntroductionRequest request) {
+        userUsecase.updateIntroduction(userId, request);
+
+        return CommonResponse.success(UPDATE_INTRODUCTION);
+    }
+
+    @PatchMapping("/me/mbti")
+    @Operation(summary = "내 정보 수정 - MBTI")
+    public CommonResponse<Void> updateMbti(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                           @Valid @RequestBody MbtiRequest request) {
+        userUsecase.updateMbti(userId, request);
+
+        return CommonResponse.success(UPDATE_MBTI);
     }
 }

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -31,7 +31,7 @@ public class UserController {
         return CommonResponse.success(COMPLETE_PROFILE);
     }
 
-    @GetMapping
+    @GetMapping("/me")
     @Operation(summary = "마이페이지 조회 API")
     public CommonResponse<UserInfoResponse> getMyInfo(@Parameter(hidden = true) @CurrentUserId Long userId) {
         UserInfoResponse response = userUsecase.getUserInfo(userId);

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -4,9 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
-import leets.leenk.domain.user.application.dto.request.MbtiRequest;
-import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
+import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.usecase.UserUsecase;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
@@ -24,6 +22,15 @@ public class UserController {
 
     private final UserUsecase userUsecase;
 
+    @PatchMapping("/me/profile")
+    @Operation(summary = "기본 정보 입력")
+    public CommonResponse<Void> completeProfile(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                            @RequestBody @Valid RegisterRequest request) {
+        userUsecase.completeProfile(userId, request);
+
+        return CommonResponse.success(COMPLETE_PROFILE);
+    }
+
     @GetMapping
     @Operation(summary = "마이페이지 조회 API")
     public CommonResponse<UserInfoResponse> getMyInfo(@Parameter(hidden = true) @CurrentUserId Long userId) {
@@ -38,6 +45,15 @@ public class UserController {
         UserInfoResponse response = userUsecase.getUserInfo(userId);
 
         return CommonResponse.success(GET_USER_INFO, response);
+    }
+
+    @PatchMapping("/me/kakao-talk-id")
+    @Operation(summary = "내 정보 수정 - 카카오톡 id")
+    public CommonResponse<Void> updateKakaoTalkId(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                   @Valid @RequestBody KakaoTalkIdRequest request) {
+        userUsecase.updateKakaoTalkId(userId, request);
+
+        return CommonResponse.success(UPDATE_KAKAO_TALK_ID);
     }
 
     @PatchMapping("/me/profile-image")

--- a/src/main/java/leets/leenk/global/auth/application/annotation/CurrentUserId.java
+++ b/src/main/java/leets/leenk/global/auth/application/annotation/CurrentUserId.java
@@ -1,0 +1,11 @@
+package leets.leenk.global.auth.application.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUserId {
+}

--- a/src/main/java/leets/leenk/global/auth/application/annotation/CurrentUserResolver.java
+++ b/src/main/java/leets/leenk/global/auth/application/annotation/CurrentUserResolver.java
@@ -1,0 +1,38 @@
+package leets.leenk.global.auth.application.annotation;
+
+import leets.leenk.global.auth.application.exception.OauthException;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static leets.leenk.global.auth.application.usecase.AuthUsecase.JWT_USER_ID_CLAIM;
+
+@Component
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentUserId.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !(authentication.getPrincipal() instanceof Jwt jwt)) {
+            throw new OauthException();
+        }
+
+        return Long.valueOf(jwt.getClaimAsString(JWT_USER_ID_CLAIM));
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/application/dto/request/KakaoAccessTokenRequest.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/request/KakaoAccessTokenRequest.java
@@ -1,9 +1,0 @@
-package leets.leenk.global.auth.application.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record KakaoAccessTokenRequest(
-        @NotBlank
-        String kakaoAccessToken
-) {
-}

--- a/src/main/java/leets/leenk/global/auth/application/dto/response/OauthErrorResponse.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/response/OauthErrorResponse.java
@@ -2,6 +2,7 @@ package leets.leenk.global.auth.application.dto.response;
 
 public record OauthErrorResponse(
         String error,
-        String error_description
+        String error_description,
+        String error_uri
 ) {
 }

--- a/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 
     USER_IN_ACTIVE(2000, HttpStatus.FORBIDDEN, "가입 승인이 허가되지 않은 계정입니다."),
     OAUTH_ERROR(2001, HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
-    UN_REGISTER(2002, HttpStatus.UNAUTHORIZED, "가입되지 않은 사용자입니다.");
+    UN_REGISTER(2002, HttpStatus.UNAUTHORIZED, "가입되지 않은 사용자입니다."),
+    ACCESS_DENIED(2003, HttpStatus.FORBIDDEN, "권한이 없습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/global/auth/application/exception/OauthException.java
+++ b/src/main/java/leets/leenk/global/auth/application/exception/OauthException.java
@@ -6,4 +6,7 @@ public class OauthException extends BaseException {
     public OauthException(String message) {
         super(ErrorCode.OAUTH_ERROR, message);
     }
+    public OauthException() {
+        super(ErrorCode.OAUTH_ERROR);
+    }
 }

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -7,7 +7,6 @@ import leets.leenk.domain.user.domain.entity.UserSetting;
 import leets.leenk.domain.user.domain.service.UserGetService;
 import leets.leenk.domain.user.domain.service.UserSaveService;
 import leets.leenk.domain.user.domain.service.UserSettingSaveService;
-import leets.leenk.global.auth.application.dto.request.KakaoAccessTokenRequest;
 import leets.leenk.global.auth.application.dto.response.LoginResponse;
 import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;
 import leets.leenk.global.auth.application.dto.response.OauthUserInfoResponse;
@@ -39,8 +38,8 @@ public class AuthUsecase {
     private final JwtDecoder jwtDecoder;
 
     @Transactional
-    public LoginResponse kakaoLogin(KakaoAccessTokenRequest kakaoAccessTokenRequest) {
-        OauthTokenResponse response = kakaoOauthApiService.getOauthToken(kakaoAccessTokenRequest.kakaoAccessToken());
+    public LoginResponse kakaoLogin(String kakaoAccessToken) {
+        OauthTokenResponse response = kakaoOauthApiService.getOauthToken(kakaoAccessToken);
 
         long userId = parseUserId(response);
         Optional<User> optionalUser = userGetService.existById(userId);

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class AuthUsecase {
-    private static final String JWT_USER_ID_CLAIM = "id";
+    public static final String JWT_USER_ID_CLAIM = "id";
 
     private final UserGetService userGetService;
     private final UserSaveService userSaveService;

--- a/src/main/java/leets/leenk/global/auth/application/util/HandlerResponseUtil.java
+++ b/src/main/java/leets/leenk/global/auth/application/util/HandlerResponseUtil.java
@@ -1,0 +1,26 @@
+package leets.leenk.global.auth.application.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import leets.leenk.global.common.exception.ErrorCodeInterface;
+import leets.leenk.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class HandlerResponseUtil {
+
+    private final ObjectMapper objectMapper;
+
+    public void setResponse(HttpServletResponse response, int status, String errorMessage, ErrorCodeInterface errorCode) throws IOException {
+        response.setStatus(status);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message = objectMapper.writeValueAsString(CommonResponse.error(errorCode, errorMessage));
+        response.getWriter().write(message);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/domain/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/leets/leenk/global/auth/domain/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,31 @@
+package leets.leenk.global.auth.domain.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import leets.leenk.global.auth.application.exception.ErrorCode;
+import leets.leenk.global.common.response.CommonResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response, accessDeniedException.getMessage());
+    }
+
+    private void setResponse(HttpServletResponse response, String errorMessage) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message = new ObjectMapper().writeValueAsString(CommonResponse.error(ErrorCode.ACCESS_DENIED, errorMessage));
+        response.getWriter().write(message);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/domain/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/leets/leenk/global/auth/domain/handler/CustomAccessDeniedHandler.java
@@ -1,11 +1,11 @@
 package leets.leenk.global.auth.domain.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leets.leenk.global.auth.application.exception.ErrorCode;
-import leets.leenk.global.common.response.CommonResponse;
+import leets.leenk.global.auth.application.util.HandlerResponseUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -13,19 +13,13 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerResponseUtil handlerResponseUtil;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        setResponse(response, accessDeniedException.getMessage());
-    }
-
-    private void setResponse(HttpServletResponse response, String errorMessage) throws IOException {
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        String message = new ObjectMapper().writeValueAsString(CommonResponse.error(ErrorCode.ACCESS_DENIED, errorMessage));
-        response.getWriter().write(message);
+        handlerResponseUtil.setResponse(response, HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage(), ErrorCode.ACCESS_DENIED);
     }
 }

--- a/src/main/java/leets/leenk/global/auth/domain/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/leets/leenk/global/auth/domain/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package leets.leenk.global.auth.domain.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import leets.leenk.global.auth.application.exception.ErrorCode;
+import leets.leenk.global.common.response.CommonResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        setResponse(response, authException.getMessage());
+    }
+
+    private void setResponse(HttpServletResponse response, String errorMessage) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        String message = new ObjectMapper().writeValueAsString(CommonResponse.error(ErrorCode.OAUTH_ERROR, errorMessage));
+        response.getWriter().write(message);
+    }
+}

--- a/src/main/java/leets/leenk/global/auth/domain/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/leets/leenk/global/auth/domain/handler/CustomAuthenticationEntryPoint.java
@@ -1,31 +1,27 @@
 package leets.leenk.global.auth.domain.handler;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import leets.leenk.global.auth.application.exception.ErrorCode;
-import leets.leenk.global.common.response.CommonResponse;
+import leets.leenk.global.auth.application.util.HandlerResponseUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final HandlerResponseUtil handlerResponseUtil;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        setResponse(response, authException.getMessage());
-    }
-
-    private void setResponse(HttpServletResponse response, String errorMessage) throws IOException {
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-
-        String message = new ObjectMapper().writeValueAsString(CommonResponse.error(ErrorCode.OAUTH_ERROR, errorMessage));
-        response.getWriter().write(message);
+        handlerResponseUtil.setResponse(response, HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage(), ErrorCode.OAUTH_ERROR);
     }
 }

--- a/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
+++ b/src/main/java/leets/leenk/global/auth/domain/service/KakaoOauthApiService.java
@@ -28,7 +28,7 @@ public class KakaoOauthApiService {
     private final KakaoOauthProperty kakaoOauthProperty;
 
     private final RestClient authRestClient;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     public OauthTokenResponse getOauthToken(String kakaoAccessToken) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
@@ -2,14 +2,12 @@ package leets.leenk.global.auth.presentation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import leets.leenk.global.auth.application.dto.request.KakaoAccessTokenRequest;
 import leets.leenk.global.auth.application.dto.response.LoginResponse;
 import leets.leenk.global.auth.application.usecase.AuthUsecase;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "AUTH")
@@ -20,8 +18,8 @@ public class AuthController {
 
     @PostMapping("/kakao/login")
     @Operation(summary = "카카오 login api [for mobile]")
-    public CommonResponse<LoginResponse> kakaoLogin(@RequestBody @Valid KakaoAccessTokenRequest kakaoAccessTokenRequest) {
-        LoginResponse response = authUsecase.kakaoLogin(kakaoAccessTokenRequest);
+    public CommonResponse<LoginResponse> kakaoLogin(@RequestHeader("Kakao-Access-Token") String kakaoAccessToken) {
+        LoginResponse response = authUsecase.kakaoLogin(kakaoAccessToken);
 
         if (response.userId() == null) {
             return CommonResponse.success(ResponseCode.LOGIN_SUCCESS, response);

--- a/src/main/java/leets/leenk/global/config/SecurityConfig.java
+++ b/src/main/java/leets/leenk/global/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package leets.leenk.global.config;
 
 
 import leets.leenk.global.auth.application.property.OauthProperty;
+import leets.leenk.global.auth.domain.handler.CustomAccessDeniedHandler;
+import leets.leenk.global.auth.domain.handler.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,6 +27,8 @@ import java.util.List;
 public class SecurityConfig {
     private final PermitUrlConfig permitUrlConfig;
     private final OauthProperty oauthProperty;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -34,7 +38,16 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfig()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling
+                                .authenticationEntryPoint(authenticationEntryPoint)
+                                .accessDeniedHandler(accessDeniedHandler))
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .jwt(jwt -> jwt
+                                .decoder(jwtDecoder())
+                        )
+                )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/leets/leenk/global/config/WebMvcConfig.java
+++ b/src/main/java/leets/leenk/global/config/WebMvcConfig.java
@@ -1,0 +1,21 @@
+package leets.leenk.global.config;
+
+import leets.leenk.global.auth.application.annotation.CurrentUserResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final CurrentUserResolver currentUserResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserResolver);
+    }
+}

--- a/src/main/java/leets/leenk/global/config/WebMvcConfig.java
+++ b/src/main/java/leets/leenk/global/config/WebMvcConfig.java
@@ -16,6 +16,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(currentUserResolver);
+        resolvers.addFirst(currentUserResolver);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #7 

## 작업 내용 💻

- 인증 서버와 연동하여 JWK 공개키를 가져오고, 액세스 토큰을 검증해 인증객체를 설정하는 로직을 구현했습니다 
- Spring Security에 기본으로 등록된 필터가 액세스 토큰을 추출, 설정한 JwtDecoder를 이용해 토큰을 검증하고 Jwt 객체를 Authentication으로 등록합니다. -> 이 정보를 CurrentUserResolver를 이용해 추출해 userId를 추출하도록 구현했습니다. (인증 및 인가를 Spring Security에 인가했다고 이해하시면 됩니다)
```
    .oauth2ResourceServer(oauth2 -> oauth2
                        .authenticationEntryPoint(authenticationEntryPoint)
                        .jwt(jwt -> jwt
                                .decoder(jwtDecoder())
                        )
                )
```
- 이 부분이 핵심으로, 이전 PR에서 Id_token을 검증하기 위해 구현한 JwtDecoder를 `oauth2ResourceServer`로 등록시켜 기본 필터를 거쳐 인증을 하도록 설정해준 부분입니다. 이 설정으로 인해 별도의 JwtCustomFilter를 구현하지 않고도 매 요청 인증을 처리할 수 있습니다
- 유저 도메인의 남은 API를 구현 완료했습니다 (유저 수정, 기본 정보 입력)
- 카카오톡 id는 필수, 그외는 null을 허용하도록 했습니다
- 이전 PR에서 카카오 액세스 토큰을 Body로 받고 있어서 이를 헤더로 받도록 수정했습니다

## 스크린샷 📷

-  토큰이 올바르지 않은 경우
<img width="665" alt="image" src="https://github.com/user-attachments/assets/82707f61-ad79-4731-b752-d1ce897c2163" />

- 토큰 발행처가 올바르지 않은 경우
<img width="722" alt="image" src="https://github.com/user-attachments/assets/cb117b53-db0f-4c04-b9eb-a329ed63ea8b" />

- 토큰이 만료된 경우
<img width="771" alt="image" src="https://github.com/user-attachments/assets/3244b8c3-8c3e-4e43-931b-f4539aa123fb" />

- 기본 정보 입력
<img width="466" alt="image" src="https://github.com/user-attachments/assets/a1cc5819-4f3f-4b75-954d-f298d72747bd" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 유저 세팅 수정의 경우는 알림이 어느정도 완료되면 그 이후에 함께 구현할 예정입니다
- 프론트 팀원과의 토의 후 개별로 정보를 수정하는 플로우에 맞게 API를 각각 구현했습니다
- 토큰 검증 및 예외처리의 경우 Spring Security에서 Jwt를 검증할 때 발생하는 메시지를 그대로 출력하도록 했습니다. 제 기준에서는 영어라서 아쉽긴 하지만, 더 구체적인 로그를 별도의 예외처리 없이 보여줄 수 있다고 판단해 이렇게 구현했는데 커스텀 예외를 잡는 것이 나을 것 같다면 말씀해 주시면 수정하겠습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 사용자가 카카오톡 ID, 프로필 이미지, 자기소개, MBTI 등 프로필 정보를 개별적으로 수정할 수 있는 PATCH API 엔드포인트가 추가되었습니다.
  - 기본 프로필 정보를 한 번에 입력하는 기능이 추가되었습니다.
  - 인증된 사용자 식별을 위한 커스텀 어노테이션 및 리졸버가 도입되었습니다.
  - 사용자 프로필 관련 응답 코드가 추가되어 성공 메시지가 명확해졌습니다.
  - OAuth2 인증 과정에서 JWT 디코더 및 커스텀 예외 처리 핸들러가 도입되어 보안 및 에러 처리 강화되었습니다.
  - 인증 토큰 전달 방식이 헤더 기반으로 변경되었습니다.
  - 인증 및 권한 오류 발생 시 JSON 형태의 커스텀 에러 응답이 제공됩니다.
  - 사용자 프로필 입력 및 수정 시 입력값 길이 제한 등 유효성 검증이 추가되었습니다.
  - API 문서화가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->