### PR TITLE
LNK-BE-8 피드 도메인 비즈니스 로직 구현

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
@@ -2,6 +2,7 @@ package leets.leenk.domain.feed.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import leets.leenk.domain.media.domain.application.dto.request.FeedMediaRequest;
 
@@ -12,6 +13,7 @@ public record FeedUploadRequest(
         String description,
 
         @Valid
+        @NotNull
         @Size(max = 3)
         List<FeedMediaRequest> media,
 

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import leets.leenk.domain.media.domain.application.dto.request.FeedMediaRequest;
+import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
 
 import java.util.List;
 

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
@@ -1,4 +1,21 @@
 package leets.leenk.domain.feed.application.dto.request;
 
-public record FeedUploadRequest() {
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import leets.leenk.domain.media.domain.application.dto.request.FeedMediaRequest;
+
+import java.util.List;
+
+public record FeedUploadRequest(
+        @Schema(description = "피드 설명", example = "행복한 링크 생활")
+        String description,
+
+        @Valid
+        @Size(max = 3)
+        List<FeedMediaRequest> media,
+
+        @Schema(description = "함께한 사용자 목록")
+        List<Long> userId
+) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/LinkedUserRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/LinkedUserRequest.java
@@ -7,6 +7,6 @@ import jakarta.validation.constraints.Positive;
 public record LinkedUserRequest(
         @NotNull @Positive
         @Schema(description = "태그할 사용자 ID")
-        long userId
+        Long userId
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/LinkedUserRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/LinkedUserRequest.java
@@ -1,4 +1,12 @@
 package leets.leenk.domain.feed.application.dto.request;
 
-public record LinkedUserRequest() {
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record LinkedUserRequest(
+        @NotNull @Positive
+        @Schema(description = "태그할 사용자 ID")
+        long userId
+) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/ReactionRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/ReactionRequest.java
@@ -1,9 +1,11 @@
 package leets.leenk.domain.feed.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record ReactionRequest(
         @NotNull
+        @Schema(description = "리액션 횟수")
         long reactionCount
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedAuthorResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedAuthorResponse.java
@@ -1,8 +1,19 @@
 package leets.leenk.domain.feed.application.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record FeedAuthorResponse(
+        @Schema(description = "작성자 id", example = "1")
         long userId,
+
+        @Schema(description = "프로필 이미지", example = "https://s3.example.com/profile_image.jpg")
         String profileImage,
+
+        @Schema(description = "작성자 이름", example = "이강혁")
         String name
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
@@ -2,7 +2,7 @@ package leets.leenk.domain.feed.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import leets.leenk.domain.media.domain.application.dto.response.FeedMediaResponse;
+import leets.leenk.domain.media.application.dto.response.FeedMediaResponse;
 import lombok.Builder;
 
 import java.time.LocalDateTime;

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
@@ -1,16 +1,32 @@
 package leets.leenk.domain.feed.application.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import leets.leenk.domain.media.domain.application.dto.response.FeedMediaResponse;
+import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record FeedDetailResponse(
+        @Schema(description = "피드 Id", example = "1")
         long feedId,
+
+        @Schema(description = "작성자 정보")
         FeedAuthorResponse author,
+
+        @Schema(description = "피드 설명", example = "행복한 링크 생활")
         String description,
+
+        @Schema(description = "피드 생성 시간", example = "2025-06-30T00:00:00")
         LocalDateTime createdAt,
+
+        @Schema(description = "피드 미디어 목록")
         List<FeedMediaResponse> media,
+
+        @Schema(description = "함께한 사용자 목록")
         List<LinkedUserResponse> linkedUser
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
@@ -1,6 +1,6 @@
 package leets.leenk.domain.feed.application.dto.response;
 
-import leets.leenk.domain.media.domain.application.FeedMediaResponse;
+import leets.leenk.domain.media.domain.application.dto.response.FeedMediaResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
@@ -20,6 +20,9 @@ public record FeedDetailResponse(
         @Schema(description = "피드 설명", example = "행복한 링크 생활")
         String description,
 
+        @Schema(description = "총 공감 수")
+        long totalReactionCount,
+
         @Schema(description = "피드 생성 시간", example = "2025-06-30T00:00:00")
         LocalDateTime createdAt,
 

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedListResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedListResponse.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.feed.application.dto.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import leets.leenk.global.common.dto.CommonPageableResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FeedListResponse(
+        @Schema(description = "피드 목록")
+        List<FeedResponse> feeds,
+
+        @Schema(description = "페이징 정보")
+        CommonPageableResponse pageable
+) {
+}

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedResponse.java
@@ -14,8 +14,8 @@ public record FeedResponse(
         @Schema(description = "작성자 정보")
         FeedAuthorResponse author,
 
-        @Schema(description = "썸네일 이미지", example = "https://s3.example.com/thumb_neil.jpg")
-        String thumbNeil,
+        @Schema(description = "썸네일 이미지", example = "https://s3.example.com/thumb_nail.jpg")
+        String thumbNail,
 
         @Schema(description = "총 공감 개수", example = "1004")
         long totalReactionCount

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedResponse.java
@@ -1,9 +1,23 @@
 package leets.leenk.domain.feed.application.dto.response;
 
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record FeedResponse(
+        @Schema(description = "피드 Id", example = "1")
         long feedId,
+
+        @Schema(description = "작성자 정보")
         FeedAuthorResponse author,
+
+        @Schema(description = "썸네일 이미지", example = "https://s3.example.com/thumb_neil.jpg")
         String thumbNeil,
+
+        @Schema(description = "총 공감 개수", example = "1004")
         long totalReactionCount
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/LinkedUserResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/LinkedUserResponse.java
@@ -1,9 +1,23 @@
 package leets.leenk.domain.feed.application.dto.response;
 
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record LinkedUserResponse(
+        @Schema(description = "작성자 id", example = "1")
         long userId,
+
+        @Schema(description = "작성자 여부", example = "true")
         boolean isAuthor,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://s3.example.com/profile_image.jpg")
         String profileImage,
+
+        @Schema(description = "사용자 이름", example = "이강혁")
         String name
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/ReactionUserResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/ReactionUserResponse.java
@@ -1,9 +1,22 @@
 package leets.leenk.domain.feed.application.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ReactionUserResponse(
+        @Schema(description = "사용자 id", example = "1")
         long userId,
+
+        @Schema(description = "프로필 이미지", example = "https://s3.example.com/profile_image.jpg")
         String profileImage,
+
+        @Schema(description = "사용자 이름", example = "이강혁")
         String name,
+
+        @Schema(description = "사용자별 공감 개수", example = "10")
         long reactionCount
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/feed/application/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package leets.leenk.domain.feed.application.exception;
+
+
+import leets.leenk.global.common.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+
+    FEED_NOT_FOUND(2200, HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/feed/application/exception/FeedNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/feed/application/exception/FeedNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.feed.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class FeedNotFoundException extends BaseException {
+    public FeedNotFoundException() {
+        super(ErrorCode.FEED_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedLinkedUserMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedLinkedUserMapper.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.feed.application.mapper;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.LinkedUser;
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeedLinkedUserMapper {
+
+    public LinkedUser toLinkedUser(User user, Feed feed) {
+        return LinkedUser.builder()
+                .feed(feed)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
@@ -36,7 +36,7 @@ public class FeedMapper {
         return FeedResponse.builder()
                 .feedId(feed.getId())
                 .author(toFeedAuthorResponse(feed))
-                .thumbNeil(thumbNeil.getMediaUrl())
+                .thumbNail(thumbNeil.getMediaUrl())
                 .totalReactionCount(feed.getTotalReactionCount())
                 .build();
     }

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
@@ -3,7 +3,7 @@ package leets.leenk.domain.feed.application.mapper;
 import leets.leenk.domain.feed.application.dto.response.*;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
-import leets.leenk.domain.media.domain.application.dto.response.FeedMediaResponse;
+import leets.leenk.domain.media.application.dto.response.FeedMediaResponse;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.global.common.dto.PageableMapperUtil;

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
@@ -1,0 +1,90 @@
+package leets.leenk.domain.feed.application.mapper;
+
+import leets.leenk.domain.feed.application.dto.response.*;
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.LinkedUser;
+import leets.leenk.domain.media.domain.application.dto.response.FeedMediaResponse;
+import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.global.common.dto.PageableMapperUtil;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class FeedMapper {
+
+    public FeedListResponse toFeedListResponse(Slice<Feed> slice, Map<Long, List<Media>> mediaMap) {
+        List<FeedResponse> responses = slice.getContent().stream()
+                .map(feed -> {
+                    List<Media> medias = mediaMap.getOrDefault(feed.getId(), List.of());
+                    Media thumbnail = medias.stream().findFirst().orElse(null);
+
+                    return toFeedResponse(feed, thumbnail);
+                })
+                .toList();
+
+        return FeedListResponse.builder()
+                .feeds(responses)
+                .pageable(PageableMapperUtil.from(slice))
+                .build();
+    }
+
+    public FeedResponse toFeedResponse(Feed feed, Media thumbNeil) {
+        return FeedResponse.builder()
+                .feedId(feed.getId())
+                .author(toFeedAuthorResponse(feed))
+                .thumbNeil(thumbNeil.getMediaUrl())
+                .totalReactionCount(feed.getTotalReactionCount())
+                .build();
+    }
+
+    public FeedAuthorResponse toFeedAuthorResponse(Feed feed) {
+        return FeedAuthorResponse.builder()
+                .userId(feed.getUser().getId())
+                .profileImage(feed.getUser().getProfileImage())
+                .name(feed.getUser().getName())
+                .build();
+    }
+
+    public Feed toFeed(User user, String description) {
+        return Feed.builder()
+                .user(user)
+                .description(description)
+                .build();
+    }
+
+    public FeedDetailResponse toFeedDetailResponse(Feed feed, List<Media> medias, List<LinkedUser> linkedUsers) {
+        return FeedDetailResponse.builder()
+                .feedId(feed.getId())
+                .author(toFeedAuthorResponse(feed))
+                .description(feed.getDescription())
+                .createdAt(feed.getCreateDate())
+                .media(toFeedMediaResponses(medias))
+                .linkedUser(toLinkedUserResponses(linkedUsers, feed))
+                .build();
+    }
+
+    private List<FeedMediaResponse> toFeedMediaResponses(List<Media> medias) {
+        return medias.stream()
+                .map(media -> FeedMediaResponse.builder()
+                        .position(media.getPosition())
+                        .mediaUrl(media.getMediaUrl())
+                        .mediaType(media.getMediaType())
+                        .build())
+                .toList();
+    }
+
+    private List<LinkedUserResponse> toLinkedUserResponses(List<LinkedUser> linkedUsers, Feed feed) {
+        return linkedUsers.stream()
+                .map(linkedUser -> LinkedUserResponse.builder()
+                        .userId(linkedUser.getUser().getId())
+                        .isAuthor(linkedUser.getUser().getId().equals(feed.getUser().getId()))
+                        .profileImage(linkedUser.getUser().getProfileImage())
+                        .name(linkedUser.getUser().getName())
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
@@ -61,6 +61,7 @@ public class FeedMapper {
                 .feedId(feed.getId())
                 .author(toFeedAuthorResponse(feed))
                 .description(feed.getDescription())
+                .totalReactionCount(feed.getTotalReactionCount())
                 .createdAt(feed.getCreateDate())
                 .media(toFeedMediaResponses(medias))
                 .linkedUser(toLinkedUserResponses(linkedUsers, feed))

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/ReactionMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/ReactionMapper.java
@@ -1,0 +1,28 @@
+package leets.leenk.domain.feed.application.mapper;
+
+import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.Reaction;
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReactionMapper {
+
+    public ReactionUserResponse toResponse(Reaction reaction) {
+        return ReactionUserResponse.builder()
+                .userId(reaction.getUser().getId())
+                .profileImage(reaction.getUser().getProfileImage())
+                .name(reaction.getUser().getName())
+                .reactionCount(reaction.getReactionCount())
+                .build();
+    }
+
+    public Reaction toReaction(User user, Feed feed, long reactionCount) {
+        return Reaction.builder()
+                .user(user)
+                .feed(feed)
+                .reactionCount(reactionCount)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -13,7 +13,7 @@ import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.feed.domain.entity.Reaction;
 import leets.leenk.domain.feed.domain.service.*;
-import leets.leenk.domain.media.domain.application.mapper.MediaMapper;
+import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.service.MediaGetService;
 import leets.leenk.domain.media.domain.service.MediaSaveService;

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -56,9 +56,6 @@ public class FeedUsecase {
     private final FeedLinkedUserMapper feedLinkedUserMapper;
     private final ReactionMapper reactionMapper;
 
-    /*
-        추후 n+1, FetchJoin과 성능 테스트 진행할 것
-     */
     @Transactional(readOnly = true)
     public FeedListResponse getFeeds(int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -60,8 +60,8 @@ public class FeedUsecase {
         추후 n+1, FetchJoin과 성능 테스트 진행할 것
      */
     @Transactional(readOnly = true)
-    public FeedListResponse getFeeds(int page, int size) {
-        Pageable pageable = PageRequest.of(page, size);
+    public FeedListResponse getFeeds(int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Slice<Feed> slice = feedGetService.findAll(pageable);
 
         List<Feed> feeds = slice.getContent();

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -23,8 +23,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -88,8 +90,8 @@ public class FeedUsecase {
     }
 
     private List<LinkedUser> getLinkedUsers(User author, List<Long> userIds, Feed feed) {
-        List<User> users = userGetService.findAll(userIds);
-        users.add(author);
+        Set<User> users = new HashSet<>(userGetService.findAll(userIds));
+        users.add(author); // 중복 자동 제거
 
         return users.stream()
                 .map(user -> feedLinkedUserMapper.toLinkedUser(user, feed))

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -3,36 +3,97 @@ package leets.leenk.domain.feed.application.usecase;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
 import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
-import leets.leenk.domain.feed.domain.service.FeedGetService;
-import leets.leenk.domain.feed.domain.service.FeedSaveService;
-import leets.leenk.domain.feed.domain.service.FeedUpdateService;
+import leets.leenk.domain.feed.application.mapper.FeedLinkedUserMapper;
+import leets.leenk.domain.feed.application.mapper.FeedMapper;
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.LinkedUser;
+import leets.leenk.domain.feed.domain.service.*;
+import leets.leenk.domain.media.domain.application.mapper.MediaMapper;
+import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.service.MediaGetService;
+import leets.leenk.domain.media.domain.service.MediaSaveService;
+import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.service.UserGetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class FeedUsecase {
 
     private final UserGetService userGetService;
+
     private final FeedGetService feedGetService;
     private final FeedSaveService feedSaveService;
     private final FeedUpdateService feedUpdateService;
 
-    public List<FeedResponse> getFeeds() {
-        return null;
+    private final MediaGetService mediaGetService;
+    private final MediaSaveService mediaSaveService;
+
+    private final LinkedUserGetService linkedUserGetService;
+    private final LinkedUserSaveService linkedUserSaveService;
+
+    private final FeedMapper feedMapper;
+    private final MediaMapper mediaMapper;
+    private final FeedLinkedUserMapper feedLinkedUserMapper;
+
+    /*
+        추후 n+1, FetchJoin과 성능 테스트 진행할 것
+     */
+    @Transactional(readOnly = true)
+    public FeedListResponse getFeeds(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<Feed> slice = feedGetService.findAll(pageable);
+
+        List<Feed> feeds = slice.getContent();
+        List<Media> medias = mediaGetService.findAll(feeds);
+
+        Map<Long, List<Media>> mediaMap = medias.stream()
+                .collect(Collectors.groupingBy(media -> media.getFeed().getId()));
+
+        return feedMapper.toFeedListResponse(slice, mediaMap);
     }
 
     public FeedDetailResponse getFeedDetail(Long feedId) {
-        return null;
+        Feed feed = feedGetService.findById(feedId);
+        List<Media> medias = mediaGetService.findAll(feed);
+        List<LinkedUser> linkedUsers = linkedUserGetService.findAll(feed);
+
+        return feedMapper.toFeedDetailResponse(feed, medias, linkedUsers);
     }
 
-    public void uploadFeed(FeedUploadRequest request) {
+    @Transactional
+    public void uploadFeed(long userId, FeedUploadRequest request) {
+        User author = userGetService.findById(userId);
+        Feed feed = feedMapper.toFeed(author, request.description());
+        feedSaveService.save(feed);
 
+        List<Media> medias = request.media().stream()
+                .map(mediaRequest -> mediaMapper.toMedia(feed, mediaRequest))
+                .toList();
+        mediaSaveService.saveAll(medias);
+
+        List<LinkedUser> linkedUsers = getLinkedUsers(author, request.userId(), feed);
+        linkedUserSaveService.saveAll(linkedUsers);
+    }
+
+    private List<LinkedUser> getLinkedUsers(User author, List<Long> userIds, Feed feed) {
+        List<User> users = userGetService.findAll(userIds);
+        users.add(author);
+
+        return users.stream()
+                .map(user -> feedLinkedUserMapper.toLinkedUser(user, feed))
+                .toList();
     }
 
     public void reactToFeed(Long feedId) {

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -73,6 +73,7 @@ public class FeedUsecase {
         return feedMapper.toFeedListResponse(slice, mediaMap);
     }
 
+    @Transactional(readOnly = true)
     public FeedDetailResponse getFeedDetail(Long feedId) {
         Feed feed = feedGetService.findById(feedId);
         List<Media> medias = mediaGetService.findAll(feed);

--- a/src/main/java/leets/leenk/domain/feed/domain/entity/Feed.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/entity/Feed.java
@@ -33,4 +33,7 @@ public class Feed extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
+    public void increaseTotalReactionCount(long totalReactionCount) {
+        this.totalReactionCount += totalReactionCount;
+    }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/entity/Feed.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/entity/Feed.java
@@ -33,7 +33,7 @@ public class Feed extends BaseEntity {
 
     private LocalDateTime deletedAt;
 
-    public void increaseTotalReactionCount(long totalReactionCount) {
-        this.totalReactionCount += totalReactionCount;
+    public void increaseTotalReactionCount(long reactionCount) {
+        this.totalReactionCount += reactionCount;
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/entity/Reaction.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/entity/Reaction.java
@@ -23,7 +23,7 @@ public class Reaction {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private int reactionCount;
+    private long reactionCount;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "feed_id", nullable = false, updatable = false)
@@ -32,4 +32,8 @@ public class Reaction {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false, updatable = false)
     private User user;
+
+    public void increaseReactionCount(long reactionCount) {
+        this.reactionCount += reactionCount;
+    }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/FeedRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/FeedRepository.java
@@ -1,7 +1,18 @@
 package leets.leenk.domain.feed.domain.repository;
 
 import leets.leenk.domain.feed.domain.entity.Feed;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+    @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL")
+    Slice<Feed> findAllByDeletedAtIsNullWithUser(Pageable pageable);
+
+    @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL AND f.id = :id")
+    Optional<Feed> findByDeletedAtIsNullAndId(Long id);
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
@@ -1,7 +1,14 @@
 package leets.leenk.domain.feed.domain.repository;
 
+import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface LinkedUserRepository extends JpaRepository<LinkedUser, Long> {
+
+    @Query("SELECT lu FROM LinkedUser lu JOIN FETCH lu.user WHERE lu.feed = :feed")
+    List<LinkedUser> findAllByFeed(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/ReactionRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/ReactionRepository.java
@@ -1,7 +1,17 @@
 package leets.leenk.domain.feed.domain.repository;
 
+import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.Reaction;
+import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+    Optional<Reaction> findByFeedAndUser(Feed feed, User user);
+
+    @Query("SELECT r FROM Reaction r JOIN FETCH r.user WHERE r.feed = :feed")
+    List<Reaction> findAllByFeed(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedGetService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedGetService.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.feed.domain.service;
 
+import leets.leenk.domain.feed.application.exception.FeedNotFoundException;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.repository.FeedRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +14,9 @@ public class FeedGetService {
 
     private final FeedRepository feedRepository;
 
-    public Feed findById(Long feedId) {
-        return feedRepository.findByDeletedAtIsNullAndId(feedId).orElseThrow(() -> new IllegalArgumentException("해당 feed가 존재하지 않습니다."));
+    public Feed findById(long feedId) {
+        return feedRepository.findByDeletedAtIsNullAndId(feedId)
+                .orElseThrow(FeedNotFoundException::new);
     }
 
     public Slice<Feed> findAll(Pageable pageable) {

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedGetService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedGetService.java
@@ -1,7 +1,10 @@
 package leets.leenk.domain.feed.domain.service;
 
+import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.repository.FeedRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,5 +13,12 @@ public class FeedGetService {
 
     private final FeedRepository feedRepository;
 
+    public Feed findById(Long feedId) {
+        return feedRepository.findByDeletedAtIsNullAndId(feedId).orElseThrow(() -> new IllegalArgumentException("해당 feed가 존재하지 않습니다."));
+    }
+
+    public Slice<Feed> findAll(Pageable pageable) {
+        return feedRepository.findAllByDeletedAtIsNullWithUser(pageable);
+    }
 
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
@@ -1,7 +1,14 @@
 package leets.leenk.domain.feed.domain.service;
 
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.Reaction;
 import org.springframework.stereotype.Service;
 
 @Service
 public class FeedUpdateService {
+
+    public void updateTotalReaction(Feed feed, Reaction reaction, long reactionCount) {
+        feed.increaseTotalReactionCount(reactionCount);
+        reaction.increaseReactionCount(reactionCount);
+    }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/service/LinkedUserGetService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/LinkedUserGetService.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.feed.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.LinkedUser;
+import leets.leenk.domain.feed.domain.repository.LinkedUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LinkedUserGetService {
+
+    private final LinkedUserRepository linkedUserRepository;
+
+    public List<LinkedUser> findAll(Feed feed) {
+        return linkedUserRepository.findAllByFeed(feed);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/domain/service/LinkedUserSaveService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/LinkedUserSaveService.java
@@ -1,0 +1,23 @@
+package leets.leenk.domain.feed.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.LinkedUser;
+import leets.leenk.domain.feed.domain.repository.LinkedUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class LinkedUserSaveService {
+
+    private final LinkedUserRepository linkedUserRepository;
+
+    public void save(LinkedUser linkedUser) {
+        linkedUserRepository.save(linkedUser);
+    }
+
+    public void saveAll(List<LinkedUser> linkedUsers) {
+        linkedUserRepository.saveAll(linkedUsers);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/domain/service/ReactionGetService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/ReactionGetService.java
@@ -1,0 +1,26 @@
+package leets.leenk.domain.feed.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.entity.Reaction;
+import leets.leenk.domain.feed.domain.repository.ReactionRepository;
+import leets.leenk.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionGetService {
+
+    private final ReactionRepository reactionRepository;
+
+    public Optional<Reaction> findByFeedAndUser(Feed feed, User user) {
+        return reactionRepository.findByFeedAndUser(feed, user);
+    }
+
+    public List<Reaction> findAll(Feed feed) {
+        return reactionRepository.findAllByFeed(feed);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/domain/service/ReactionSaveService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/ReactionSaveService.java
@@ -1,0 +1,16 @@
+package leets.leenk.domain.feed.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.Reaction;
+import leets.leenk.domain.feed.domain.repository.ReactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReactionSaveService {
+    private final ReactionRepository reactionRepository;
+
+    public Reaction save(Reaction reaction) {
+        return reactionRepository.save(reaction);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -1,15 +1,18 @@
 package leets.leenk.domain.feed.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
+import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
 import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
 import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
 import leets.leenk.domain.feed.application.usecase.FeedUsecase;
+import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,16 +28,17 @@ public class FeedController {
     private final FeedUsecase feedUsecase;
 
     @GetMapping
-    @Operation(summary = "피드 조회 API")
-    public CommonResponse<List<FeedResponse>> getFeeds() {
-        List<FeedResponse> response = feedUsecase.getFeeds();
+    @Operation(summary = "피드 조회 API - 무한 스크롤")
+    public CommonResponse<FeedListResponse> getFeeds(@RequestParam int page,
+                                                        @RequestParam int size) {
+        FeedListResponse response = feedUsecase.getFeeds(page, size);
 
         return CommonResponse.success(ResponseCode.GET_ALL_FEED, response);
     }
 
     @GetMapping("/{feedId}")
     @Operation(summary = "피드 상세 조회 API")
-    public CommonResponse<FeedDetailResponse> getFeedDetail(@PathVariable @Positive Long feedId) {
+    public CommonResponse<FeedDetailResponse> getFeedDetail(@PathVariable @Positive long feedId) {
         FeedDetailResponse response = feedUsecase.getFeedDetail(feedId);
 
         return CommonResponse.success(ResponseCode.GET_FEED_DETAIL, response);
@@ -42,31 +46,35 @@ public class FeedController {
 
     @PostMapping
     @Operation(summary = "피드 업로드 API")
-    public CommonResponse<Void> uploadFeed(@RequestBody @Valid FeedUploadRequest request) {
-        feedUsecase.uploadFeed(request);
+    public CommonResponse<Void> uploadFeed(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                           @RequestBody @Valid FeedUploadRequest request) {
+        feedUsecase.uploadFeed(userId, request);
 
         return CommonResponse.success(ResponseCode.UPLOAD_FEED);
     }
 
     @PostMapping("/{feedId}/reactions")
     @Operation(summary = "공감하기 API")
-    public CommonResponse<Void> reactToFeed(@PathVariable @Positive Long feedId) {
-        feedUsecase.reactToFeed(feedId);
+    public CommonResponse<Void> reactToFeed(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                            @PathVariable @Positive long feedId,
+                                            @RequestBody @Valid ReactionRequest request) {
+        feedUsecase.reactToFeed(userId, feedId, request);
 
         return CommonResponse.success(ResponseCode.CREATE_REACTION);
     }
 
     @GetMapping("/{feedId}/reactions")
     @Operation(summary = "피드 공감 유저 목록 조회 API")
-    public CommonResponse<List<ReactionUserResponse>> getLikedUsers(@PathVariable @Positive Long feedId) {
-        List<ReactionUserResponse> response = feedUsecase.getLikedUsers(feedId);
+    public CommonResponse<List<ReactionUserResponse>> getLikedUsers(@PathVariable @Positive long feedId) {
+        List<ReactionUserResponse> response = feedUsecase.getReactionUser(feedId);
 
         return CommonResponse.success(ResponseCode.GET_REACTED_USERS, response);
     }
 
     @PatchMapping
     @Operation(summary = "피드 수정 API")
-    public CommonResponse<Void> updateFeed(@RequestBody @Valid FeedUpdateRequest request) {
+    public CommonResponse<Void> updateFeed(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                           @RequestBody @Valid FeedUpdateRequest request) {
         feedUsecase.updateFeed(request);
 
         return CommonResponse.success(ResponseCode.UPDATE_FEED);

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -29,9 +29,9 @@ public class FeedController {
 
     @GetMapping
     @Operation(summary = "피드 조회 API - 무한 스크롤")
-    public CommonResponse<FeedListResponse> getFeeds(@RequestParam int page,
-                                                        @RequestParam int size) {
-        FeedListResponse response = feedUsecase.getFeeds(page, size);
+    public CommonResponse<FeedListResponse> getFeeds(@RequestParam int pageNumber,
+                                                        @RequestParam int pageSize) {
+        FeedListResponse response = feedUsecase.getFeeds(pageNumber, pageSize);
 
         return CommonResponse.success(ResponseCode.GET_ALL_FEED, response);
     }

--- a/src/main/java/leets/leenk/domain/media/application/dto/request/FeedMediaRequest.java
+++ b/src/main/java/leets/leenk/domain/media/application/dto/request/FeedMediaRequest.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.media.domain.application.dto.request;
+package leets.leenk.domain.media.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/leets/leenk/domain/media/application/dto/response/FeedMediaResponse.java
+++ b/src/main/java/leets/leenk/domain/media/application/dto/response/FeedMediaResponse.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.media.domain.application.dto.response;
+package leets.leenk.domain.media.application.dto.response;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/leets/leenk/domain/media/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/media/application/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.media.domain.application.exception;
+package leets.leenk.domain.media.application.exception;
 
 import leets.leenk.global.common.exception.ErrorCodeInterface;
 import lombok.AllArgsConstructor;

--- a/src/main/java/leets/leenk/domain/media/application/exception/MediaNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/media/application/exception/MediaNotFoundException.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.media.domain.application.exception;
+package leets.leenk.domain.media.application.exception;
 
 import leets.leenk.global.common.exception.BaseException;
 

--- a/src/main/java/leets/leenk/domain/media/application/mapper/MediaMapper.java
+++ b/src/main/java/leets/leenk/domain/media/application/mapper/MediaMapper.java
@@ -1,7 +1,7 @@
-package leets.leenk.domain.media.domain.application.mapper;
+package leets.leenk.domain.media.application.mapper;
 
 import leets.leenk.domain.feed.domain.entity.Feed;
-import leets.leenk.domain.media.domain.application.dto.request.FeedMediaRequest;
+import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
 import leets.leenk.domain.media.domain.entity.Media;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/leets/leenk/domain/media/domain/application/dto/request/FeedMediaRequest.java
+++ b/src/main/java/leets/leenk/domain/media/domain/application/dto/request/FeedMediaRequest.java
@@ -1,18 +1,21 @@
-package leets.leenk.domain.media.domain.application.dto.response;
-
+package leets.leenk.domain.media.domain.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import leets.leenk.domain.media.domain.entity.enums.MediaType;
-import lombok.Builder;
 
-@Builder
-public record FeedMediaResponse(
-        @Schema(description = "1부터 시작하는 정수", example = "1")
+public record FeedMediaRequest(
+        @NotNull
+        @Positive
+        @Schema(description = "1부터 시작하는 정수")
         int position,
 
+        @NotNull
         @Schema(description = "미디어 S3 URL", example = "https://s3.example.com/image.jpg")
         String mediaUrl,
 
+        @NotNull
         @Schema(description = "이미지, 비디오", example = "IMAGE or VIDEO")
         MediaType mediaType
 ) {

--- a/src/main/java/leets/leenk/domain/media/domain/application/dto/request/FeedMediaRequest.java
+++ b/src/main/java/leets/leenk/domain/media/domain/application/dto/request/FeedMediaRequest.java
@@ -1,6 +1,7 @@
 package leets.leenk.domain.media.domain.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import leets.leenk.domain.media.domain.entity.enums.MediaType;
@@ -9,9 +10,9 @@ public record FeedMediaRequest(
         @NotNull
         @Positive
         @Schema(description = "1부터 시작하는 정수")
-        int position,
+        Integer position,
 
-        @NotNull
+        @NotBlank
         @Schema(description = "미디어 S3 URL", example = "https://s3.example.com/image.jpg")
         String mediaUrl,
 

--- a/src/main/java/leets/leenk/domain/media/domain/application/dto/response/FeedMediaResponse.java
+++ b/src/main/java/leets/leenk/domain/media/domain/application/dto/response/FeedMediaResponse.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.media.domain.application;
+package leets.leenk.domain.media.domain.application.dto.response;
 
 
 import leets.leenk.domain.media.domain.entity.enums.MediaType;

--- a/src/main/java/leets/leenk/domain/media/domain/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/media/domain/application/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.media.domain.application.exception;
+
+import leets.leenk.global.common.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+
+    MEDIA_NOT_FOUND(2500, HttpStatus.NOT_FOUND, "존재하지 않는 미디어입니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/media/domain/application/exception/MediaNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/media/domain/application/exception/MediaNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.media.domain.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class MediaNotFoundException extends BaseException {
+    public MediaNotFoundException() {
+        super(ErrorCode.MEDIA_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/application/mapper/MediaMapper.java
+++ b/src/main/java/leets/leenk/domain/media/domain/application/mapper/MediaMapper.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.media.domain.application.mapper;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.media.domain.application.dto.request.FeedMediaRequest;
+import leets.leenk.domain.media.domain.entity.Media;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MediaMapper {
+
+    public Media toMedia(Feed feed, FeedMediaRequest request) {
+        return Media.builder()
+                .feed(feed)
+                .position(request.position())
+                .mediaUrl(request.mediaUrl())
+                .mediaType(request.mediaType())
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/entity/Media.java
+++ b/src/main/java/leets/leenk/domain/media/domain/entity/Media.java
@@ -36,10 +36,10 @@ public class Media {
     private int position;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "feed_id", nullable = false, updatable = false)
+    @JoinColumn(name = "feed_id", updatable = false)
     private Feed feed;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "leenk_id", nullable = false, updatable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leenk_id", updatable = false)
     private Leenk leenk;
 }

--- a/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
+++ b/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
@@ -10,5 +10,5 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
 
     List<Media> findAllByFeedInOrderByPosition(List<Feed> feeds);
 
-    List<Media> findAllByFeed(Feed feed);
+    List<Media> findAllByFeedOrderByPosition(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
+++ b/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
@@ -1,0 +1,14 @@
+package leets.leenk.domain.media.domain.repository;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.media.domain.entity.Media;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MediaRepository extends JpaRepository<Media, Long> {
+
+    List<Media> findAllByFeedInOrderByPosition(List<Feed> feeds);
+
+    List<Media> findAllByFeed(Feed feed);
+}

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
@@ -1,0 +1,28 @@
+package leets.leenk.domain.media.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.repository.MediaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MediaGetService {
+
+    private final MediaRepository mediaRepository;
+
+    public Media findById(long mediaId) {
+        return mediaRepository.findById(mediaId).orElseThrow();
+    }
+
+    public List<Media> findAll(Feed feed) {
+        return mediaRepository.findAllByFeed(feed);
+    }
+
+    public List<Media> findAll(List<Feed> feeds) {
+        return mediaRepository.findAllByFeedInOrderByPosition(feeds);
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
@@ -1,7 +1,7 @@
 package leets.leenk.domain.media.domain.service;
 
 import leets.leenk.domain.feed.domain.entity.Feed;
-import leets.leenk.domain.media.domain.application.exception.MediaNotFoundException;
+import leets.leenk.domain.media.application.exception.MediaNotFoundException;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
@@ -1,6 +1,7 @@
 package leets.leenk.domain.media.domain.service;
 
 import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.media.domain.application.exception.MediaNotFoundException;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +16,8 @@ public class MediaGetService {
     private final MediaRepository mediaRepository;
 
     public Media findById(long mediaId) {
-        return mediaRepository.findById(mediaId).orElseThrow();
+        return mediaRepository.findById(mediaId)
+                .orElseThrow(MediaNotFoundException::new);
     }
 
     public List<Media> findAll(Feed feed) {

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
@@ -19,7 +19,7 @@ public class MediaGetService {
     }
 
     public List<Media> findAll(Feed feed) {
-        return mediaRepository.findAllByFeed(feed);
+        return mediaRepository.findAllByFeedOrderByPosition(feed);
     }
 
     public List<Media> findAll(List<Feed> feeds) {

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaSaveService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaSaveService.java
@@ -1,0 +1,23 @@
+package leets.leenk.domain.media.domain.service;
+
+import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.repository.MediaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MediaSaveService {
+
+    private final MediaRepository mediaRepository;
+
+    public void save(Media media) {
+        mediaRepository.save(media);
+    }
+
+    public void saveAll(List<Media> mediaList) {
+        mediaRepository.saveAll(mediaList);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -67,4 +67,16 @@ public class User extends BaseEntity {
     public void updateMbti(String mbti) {
         this.mbti = mbti;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
+        return id != null && id.equals(user.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
@@ -3,5 +3,9 @@ package leets.leenk.domain.user.domain.repository;
 import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    List<User> findAllByIdIn(List<Long> userIds);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
@@ -6,6 +6,7 @@ import leets.leenk.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -21,5 +22,9 @@ public class UserGetService {
 
     public Optional<User> existById(long userId) {
         return userRepository.findById(userId);
+    }
+
+    public List<User> findAll(List<Long> userIds) {
+        return userRepository.findAllByIdIn(userIds);
     }
 }

--- a/src/main/java/leets/leenk/global/common/dto/CommonPageableResponse.java
+++ b/src/main/java/leets/leenk/global/common/dto/CommonPageableResponse.java
@@ -1,0 +1,25 @@
+package leets.leenk.global.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CommonPageableResponse(
+        @Schema(description = "페이지 번호 (0부터 시작)", example = "0")
+        int pageNumber,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int pageSize,
+
+        @Schema(description = "현재 페이지의 요소 개수", example = "10")
+        int numberOfElements,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext,
+
+        @Schema(description = "현재 페이지의 요소가 비어 있는지의 여부", example = "false")
+        boolean empty
+) {
+}

--- a/src/main/java/leets/leenk/global/common/dto/PageableMapperUtil.java
+++ b/src/main/java/leets/leenk/global/common/dto/PageableMapperUtil.java
@@ -1,0 +1,26 @@
+package leets.leenk.global.common.dto;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
+public class PageableMapperUtil {
+    public static CommonPageableResponse from(Slice<?> slice) {
+        return CommonPageableResponse.builder()
+                .pageNumber(slice.getNumber())
+                .pageSize(slice.getSize())
+                .numberOfElements(slice.getNumberOfElements())
+                .hasNext(slice.hasNext())
+                .empty(slice.isEmpty())
+                .build();
+    }
+
+    public static CommonPageableResponse from(Page<?> page) {
+        return CommonPageableResponse.builder()
+                .pageNumber(page.getNumber())
+                .pageSize(page.getSize())
+                .numberOfElements(page.getNumberOfElements())
+                .hasNext(page.hasNext()) // or isLast(), etc.
+                .empty(page.isEmpty())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,3 +3,10 @@ spring:
     active: local
   jpa:
     open-in-view: false
+
+springdoc:
+  swagger-ui:
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true
+


### PR DESCRIPTION
## Related issue 🛠
- closed #17 

## 작업 내용 💻

- 피드 도메인 관련 비즈니스 로직 & API를 구현했습니다
- 전체 조회는 무한 스크롤로 구현하였고, 성능 최적화를 위해 N+1을 배제하고자 전부 가져와서 Map으로 그룹화 하여 매핑하는 방식을 채택했습니다. 시간상 다른 방식과 테스트는 못해서 다음 작업에서 테스트 + 최적화 할 예정입니다
- 상세 조회시에는 피드 + 함께한 유저를 같이 보내주고, 공감한 유저는 별도의 API로 조회하도록 구현했습니다
- 프론트엔드 구현 용이성을 위해 스웨거 스키마 작성을 해뒀습니다. 예외처리나 응답은 다음 작업에서 해보겠습니다 (코드가 너무 길어져서..)
- 응답 dto에는 전부 null인 경우 전송하지 않도록 JsonInclude를 설정해뒀습니다
- 이미지도 모두 정렬되는 것 확인했습니다
- 공감의 경우는 고민을 많이 해봤는데, 서버에서 처리하기에는 네트워크 트래픽이 감당이 안될거라고 판단해서 프론트 단에서 한 번에 개수를 모아서 보내주는 쪽으로 해보기로 했습니다. (오늘 프론트 작업자 분께 전달 예쩡..)

## 스크린샷 📷

- 전체 조회
<img width="633" alt="image" src="https://github.com/user-attachments/assets/22785796-20fb-4285-b762-65e337cb892e" />

- 상세 조회
<img width="499" alt="image" src="https://github.com/user-attachments/assets/99365fc4-2504-40f1-bceb-ffa7b642648c" />

- 공감한 유저 조회
<img width="442" alt="image" src="https://github.com/user-attachments/assets/c9535cf1-10c6-4383-a786-38266bfa50f5" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- OSIV를 꺼둬서 LAZY 쿼리가 동작을 안 함에 따라 연관관계 객체를 사용하는 경우 fetch join으로 함께 가져와야합니당 (페치 조인이 문제가 아니라 트랜잭션을 읽기 전용도 꼭 열어줘야함)
- 매퍼는 깔끔하게 해본다고 하긴 했는데, 좀 분리하는게 나을가요.?
- 썸네일의 경우는 이미지 리사이징이 필요해 보여서 아직은 임시 로직이고 프론트 작업자 분들과 소통해서 어떻게 할지 결정해보겠습니다. 고민인게 1. 모든 이미지를 리사이징 하고 1번 이미지를 썸네일로 보여준다. 2. 리사이징된 썸네일만 따로 저장해서 반환한다.

- 코드가 길어져서 정말 죄송할 따름입니다 여러분 ㅠㅠㅠㅠ 좀 급하게 구현한 느낌이 없지 않아 있어서 올려놓고 계속 수정할게욥 😭



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 피드 목록 조회, 상세 조회, 피드 생성(미디어 및 태그 유저 포함), 리액션 관리, 무한 스크롤(페이지네이션) 기능이 추가되었습니다.
  - 미디어 및 리액션 관련 요청/응답 DTO와 매퍼, 서비스 계층이 도입되었습니다.
  - 피드, 미디어, 리액션, 태그 유저에 대한 상세 API 응답 구조 및 예시가 Swagger 문서에 반영되었습니다.

- **버그 수정**
  - 일부 필드명 오타(thumbNeil → thumbNail)가 수정되었습니다.

- **개선 및 리팩터링**
  - 엔티티 및 DTO에 빌더 패턴, null 제외 직렬화, Swagger 문서화 어노테이션이 적용되었습니다.
  - 사용자, 피드, 미디어 등 엔티티의 equals/hashCode 오버라이드로 ID 기반 비교가 가능해졌습니다.

- **기타**
  - Swagger UI에서 메서드/태그 정렬 및 요청 소요시간 표시 옵션이 추가되었습니다.
  - 예외 코드 및 예외 클래스가 도입되어 도메인별 상세 오류 처리가 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->