### PR TITLE
LNK-BE-10 사용자 설정 및 의견 남기기

### DIFF
--- a/src/main/java/leets/leenk/LeenkApplication.java
+++ b/src/main/java/leets/leenk/LeenkApplication.java
@@ -3,9 +3,11 @@ package leets.leenk;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableAsync
 public class LeenkApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/FeedbackRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/FeedbackRequest.java
@@ -2,10 +2,12 @@ package leets.leenk.domain.user.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record FeedbackRequest(
-        @Schema(description = "피드백", example = "~~ 기능 추가해주세요!")
         @NotBlank
+        @Size(max = 200)
+        @Schema(description = "피드백", example = "~~ 기능 추가해주세요!")
         String feedback
 ) {
 }

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/FeedbackRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/FeedbackRequest.java
@@ -1,0 +1,11 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record FeedbackRequest(
+        @Schema(description = "피드백", example = "~~ 기능 추가해주세요!")
+        @NotBlank
+        String feedback
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/NotificationSettingUpdateRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/NotificationSettingUpdateRequest.java
@@ -1,0 +1,18 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NotificationSettingUpdateRequest(
+        @Schema(description = "새로운 링크 알림 여부 수정", example = "false")
+        Boolean newLeenkNotify,
+
+        @Schema(description = "링크 상태 변경 알림 여부 수정", example = "false")
+        Boolean leenkStatusNotify,
+
+        @Schema(description = "새로운 피드 알림 여부 수정", example = "false")
+        Boolean newFeedNotify,
+
+        @Schema(description = "새로운 공감 알림 여부 수정", example = "false")
+        Boolean newReactionNotify
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/response/NotificationSettingResponse.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/response/NotificationSettingResponse.java
@@ -1,0 +1,22 @@
+package leets.leenk.domain.user.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record NotificationSettingResponse(
+        @Schema(description = "새로운 링크 알림", example = "true")
+        boolean isNewLeenkNotify,
+
+        @Schema(description = "링크 상태 변경 알림", example = "true")
+        boolean isLeenkStatusNotify,
+
+        @Schema(description = "새로운 피드 알림", example = "true")
+        boolean isNewFeedNotify,
+
+        @Schema(description = "공감 알림", example = "true")
+        boolean isNewReactionNotify
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/dto/response/UserInfoResponse.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/response/UserInfoResponse.java
@@ -12,7 +12,6 @@ public record UserInfoResponse(
         String profileImage,
         String kakaoTalkId,
         String introduction,
-        String mbti,
-        long totalReactionCount
+        String mbti
 ) {
 }

--- a/src/main/java/leets/leenk/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/ErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
 
-    USER_NOT_FOUND(2100, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다.");
+    USER_NOT_FOUND(2100, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
+    USER_SETTING_NOT_FOUND(2101, HttpStatus.NOT_FOUND, "존재하지 않는 사용자 설정입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/application/exception/UserSettingNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/UserSettingNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class UserSettingNotFoundException extends BaseException {
+    public UserSettingNotFoundException() {
+        super(ErrorCode.USER_SETTING_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/mapper/UserMapper.java
+++ b/src/main/java/leets/leenk/domain/user/application/mapper/UserMapper.java
@@ -18,7 +18,6 @@ public class UserMapper {
                 .kakaoTalkId(user.getKakaoTalkId())
                 .introduction(user.getIntroduction())
                 .mbti(user.getMbti())
-                .totalReactionCount(user.getTotalReactionCount())
                 .build();
     }
 

--- a/src/main/java/leets/leenk/domain/user/application/mapper/UserSettingMapper.java
+++ b/src/main/java/leets/leenk/domain/user/application/mapper/UserSettingMapper.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.user.application.mapper;
 
+import leets.leenk.domain.user.application.dto.response.NotificationSettingResponse;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserSetting;
 import org.springframework.stereotype.Component;
@@ -14,6 +15,15 @@ public class UserSettingMapper {
                 .isNewFeedNotify(true)
                 .isNewReactionNotify(true)
                 .user(user)
+                .build();
+    }
+
+    public NotificationSettingResponse toNotificationSettingResponse(UserSetting userSetting) {
+        return NotificationSettingResponse.builder()
+                .isNewLeenkNotify(userSetting.isNewLeenkNotify())
+                .isLeenkStatusNotify(userSetting.isLeenkStatusNotify())
+                .isNewFeedNotify(userSetting.isNewFeedNotify())
+                .isNewReactionNotify(userSetting.isNewReactionNotify())
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.user.application.usecase;
+
+import leets.leenk.domain.user.domain.service.NotionDatabaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSettingUsecase {
+
+    private final NotionDatabaseService notionDatabaseService;
+
+    // 알림 설정 변경
+
+
+    // 의견 남기기 (슬랙 + 노션 DB)
+    public void sendFeedback(String feedback) {
+        notionDatabaseService.sendFeedback(feedback);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
@@ -1,19 +1,43 @@
 package leets.leenk.domain.user.application.usecase;
 
-import leets.leenk.domain.user.domain.service.NotionDatabaseService;
-import leets.leenk.domain.user.domain.service.SlackWebhookService;
+import leets.leenk.domain.user.application.dto.request.NotificationSettingUpdateRequest;
+import leets.leenk.domain.user.application.dto.response.NotificationSettingResponse;
+import leets.leenk.domain.user.application.mapper.UserSettingMapper;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserSetting;
+import leets.leenk.domain.user.domain.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class UserSettingUsecase {
 
+    private final UserGetService userGetService;
+    private final UserSettingGetService userSettingGetService;
+    private final UserSettingUpdateService userSettingUpdateService;
+
     private final NotionDatabaseService notionDatabaseService;
     private final SlackWebhookService slackWebhookService;
 
-    // 알림 설정 변경
+    private final UserSettingMapper userSettingMapper;
 
+    @Transactional(readOnly = true)
+    public NotificationSettingResponse getNotificationSetting(long userId) {
+        User user = userGetService.findById(userId);
+        UserSetting userSetting = userSettingGetService.findByUser(user);
+
+        return userSettingMapper.toNotificationSettingResponse(userSetting);
+    }
+
+    @Transactional
+    public void updateNotifications(long userId, NotificationSettingUpdateRequest request) {
+        User user = userGetService.findById(userId);
+        UserSetting userSetting = userSettingGetService.findByUser(user);
+
+        userSettingUpdateService.updateNotificationSetting(userSetting, request);
+    }
 
     public void sendFeedback(String feedback) {
         notionDatabaseService.sendFeedback(feedback);

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
@@ -1,6 +1,7 @@
 package leets.leenk.domain.user.application.usecase;
 
 import leets.leenk.domain.user.domain.service.NotionDatabaseService;
+import leets.leenk.domain.user.domain.service.SlackWebhookService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,12 +10,13 @@ import org.springframework.stereotype.Service;
 public class UserSettingUsecase {
 
     private final NotionDatabaseService notionDatabaseService;
+    private final SlackWebhookService slackWebhookService;
 
     // 알림 설정 변경
 
 
-    // 의견 남기기 (슬랙 + 노션 DB)
     public void sendFeedback(String feedback) {
         notionDatabaseService.sendFeedback(feedback);
+        slackWebhookService.sendFeedback(feedback);
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/UserSetting.java
@@ -34,4 +34,21 @@ public class UserSetting extends BaseEntity {
     @OneToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+
+    public void updateIsNewLeenkNotify(boolean isNewLeenkNotify) {
+        this.isNewLeenkNotify = isNewLeenkNotify;
+    }
+
+    public void updateIsLeenkStatusNotify(boolean isLeenkStatusNotify) {
+        this.isLeenkStatusNotify = isLeenkStatusNotify;
+    }
+
+    public void updateIsNewFeedNotify(boolean isNewFeedNotify) {
+        this.isNewFeedNotify = isNewFeedNotify;
+    }
+
+    public void updateIsNewReactionNotify(boolean isNewReactionNotify) {
+        this.isNewReactionNotify = isNewReactionNotify;
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserSettingRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserSettingRepository.java
@@ -1,7 +1,11 @@
 package leets.leenk.domain.user.domain.repository;
 
+import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
+    Optional<UserSetting> findByUser(User user);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/NotionDatabaseService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/NotionDatabaseService.java
@@ -1,0 +1,61 @@
+package leets.leenk.domain.user.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotionDatabaseService {
+
+    private static final String NOTION_INSERT_URI = "https://api.notion.com/v1/pages/";
+
+    @Value("${notion.token}")
+    private String NOTION_TOKEN;
+
+    @Value("${notion.database_id}")
+    private String DATABASE_ID;
+
+    @Value("${notion.version}")
+    private String NOTION_VERSION;
+
+    private final RestClient notionRestClient;
+
+    @Async
+    public void sendFeedback(String feedback) {
+        String today = LocalDate.now().toString();
+
+        Map<String, Object> requestBody = Map.of(
+                "parent", Map.of(
+                        "type", "database_id",
+                        "database_id", DATABASE_ID
+                ),
+                "properties", Map.of(
+                        "피드백", Map.of(
+                                "title", List.of(
+                                        Map.of("text", Map.of("content", feedback))
+                                )
+                        ),
+                        "날짜", Map.of(
+                                "date", Map.of("start", today)
+                        )
+                )
+        );
+
+        notionRestClient.post()
+                .uri(NOTION_INSERT_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + NOTION_TOKEN)
+                .header("Notion-Version", NOTION_VERSION)
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .body(requestBody)
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/SlackWebhookService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/SlackWebhookService.java
@@ -1,0 +1,29 @@
+package leets.leenk.domain.user.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class SlackWebhookService {
+
+    @Value("${slack.webhook_url}")
+    private String webhookUrl;
+
+    private final RestClient slackRestClient;
+
+    public void sendFeedback(String feedback) {
+        String formatted = "*[링크 서비스 피드백]*\n```" + feedback + "```";
+
+        slackRestClient.post()
+                .uri(webhookUrl)
+                .header("Content-Type", "application/json")
+                .body(Map.of("text", formatted))
+                .retrieve()
+                .toBodilessEntity();
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserSettingGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserSettingGetService.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.user.domain.service;
+
+import leets.leenk.domain.user.application.exception.UserSettingNotFoundException;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserSetting;
+import leets.leenk.domain.user.domain.repository.UserSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserSettingGetService {
+
+    private final UserSettingRepository userSettingRepository;
+
+    public UserSetting findByUser(User user) {
+        return userSettingRepository.findByUser(user)
+                .orElseThrow(UserSettingNotFoundException::new);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserSettingUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserSettingUpdateService.java
@@ -1,0 +1,27 @@
+package leets.leenk.domain.user.domain.service;
+
+import leets.leenk.domain.user.application.dto.request.NotificationSettingUpdateRequest;
+import leets.leenk.domain.user.domain.entity.UserSetting;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserSettingUpdateService {
+
+    public void updateNotificationSetting(UserSetting userSetting, NotificationSettingUpdateRequest request) {
+        if (request.newLeenkNotify() != null) {
+            userSetting.updateIsNewLeenkNotify(request.newLeenkNotify());
+        }
+
+        if (request.leenkStatusNotify() != null) {
+            userSetting.updateIsLeenkStatusNotify(request.leenkStatusNotify());
+        }
+
+        if (request.newFeedNotify() != null) {
+            userSetting.updateIsNewFeedNotify(request.newFeedNotify());
+        }
+
+        if (request.newReactionNotify() != null) {
+            userSetting.updateIsNewReactionNotify(request.newReactionNotify());
+        }
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -17,7 +17,10 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다."),
     COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
 
-    SEND_FEEDBACK(1107, HttpStatus.OK, "의견 남기기에 성공했습니다.");
+
+    GET_NOTIFICATION_SETTING(1110, HttpStatus.OK, "알림 설정 조회에 성공했습니다."),
+    UPDATE_NOTIFICATION_SETTING(1111, HttpStatus.OK, "알림 설정 수정에 성공했습니다."),
+    SEND_FEEDBACK(1112, HttpStatus.OK, "의견 남기기에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -15,7 +15,9 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPDATE_INTRODUCTION(1103, HttpStatus.OK, "자기소개 수정에 성공했습니다."),
     UPDATE_MBTI(1104, HttpStatus.OK, "MBTI 수정에 성공했습니다."),
     UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다."),
-    COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다.");
+    COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
+
+    SEND_FEEDBACK(1107, HttpStatus.OK, "의견 남기기에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
@@ -1,0 +1,30 @@
+package leets.leenk.domain.user.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import leets.leenk.domain.user.application.dto.request.FeedbackRequest;
+import leets.leenk.domain.user.application.usecase.UserSettingUsecase;
+import leets.leenk.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "USER-SETTING")
+@RestController
+@RequestMapping("/user-setting")
+@RequiredArgsConstructor
+public class UserSettingController {
+
+    private final UserSettingUsecase userSettingUsecase;
+
+    @PostMapping("/feedback")
+    @Operation(summary = "의견 남기기 API")
+    public CommonResponse<Void> sendFeedback(@RequestBody @Valid FeedbackRequest request) {
+        userSettingUsecase.sendFeedback(request.feedback());
+
+        return CommonResponse.success(ResponseCode.SEND_FEEDBACK);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
@@ -24,10 +24,10 @@ public class UserSettingController {
 
     @GetMapping("/notifications")
     @Operation(
-            summary = "알림 조회하기 API",
+            summary = "알림 설정 조회하기 API",
             description = "알림 설정을 위한 조회 API입니다."
     )
-    public CommonResponse<NotificationSettingResponse> getNotifications(@Parameter(hidden = true) @CurrentUserId Long userId) {
+    public CommonResponse<NotificationSettingResponse> getNotificationSetting(@Parameter(hidden = true) @CurrentUserId Long userId) {
         NotificationSettingResponse response = userSettingUsecase.getNotificationSetting(userId);
 
         return CommonResponse.success(ResponseCode.GET_NOTIFICATION_SETTING, response);

--- a/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
@@ -36,7 +36,7 @@ public class UserSettingController {
     @PatchMapping("/notifications")
     @Operation(
             summary = "알림 설정하기 API",
-            description = "PATCH 메서드에 맞게, 수정할 항목의 값만 변경해서 넣어주세요. (피드 좋아요 끄기 -> isNewReactionNotify: false, 나머지는 생략)"
+            description = "PATCH 메서드에 맞게, 수정할 항목의 값만 변경해서 넣어주세요. (피드 좋아요 알림 끄기 -> newReactionNotify: false, 나머지는 생략)"
     )
     public CommonResponse<Void> updateNotifications(@Parameter(hidden = true) @CurrentUserId Long userId,
                                                     @RequestBody @Valid NotificationSettingUpdateRequest request) {

--- a/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserSettingController.java
@@ -1,16 +1,17 @@
 package leets.leenk.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.leenk.domain.user.application.dto.request.FeedbackRequest;
+import leets.leenk.domain.user.application.dto.request.NotificationSettingUpdateRequest;
+import leets.leenk.domain.user.application.dto.response.NotificationSettingResponse;
 import leets.leenk.domain.user.application.usecase.UserSettingUsecase;
+import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "USER-SETTING")
 @RestController
@@ -20,8 +21,35 @@ public class UserSettingController {
 
     private final UserSettingUsecase userSettingUsecase;
 
+
+    @GetMapping("/notifications")
+    @Operation(
+            summary = "알림 조회하기 API",
+            description = "알림 설정을 위한 조회 API입니다."
+    )
+    public CommonResponse<NotificationSettingResponse> getNotifications(@Parameter(hidden = true) @CurrentUserId Long userId) {
+        NotificationSettingResponse response = userSettingUsecase.getNotificationSetting(userId);
+
+        return CommonResponse.success(ResponseCode.GET_NOTIFICATION_SETTING, response);
+    }
+
+    @PatchMapping("/notifications")
+    @Operation(
+            summary = "알림 설정하기 API",
+            description = "PATCH 메서드에 맞게, 수정할 항목의 값만 변경해서 넣어주세요. (피드 좋아요 끄기 -> isNewReactionNotify: false, 나머지는 생략)"
+    )
+    public CommonResponse<Void> updateNotifications(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                    @RequestBody @Valid NotificationSettingUpdateRequest request) {
+        userSettingUsecase.updateNotifications(userId, request);
+
+        return CommonResponse.success(ResponseCode.UPDATE_NOTIFICATION_SETTING);
+    }
+
     @PostMapping("/feedback")
-    @Operation(summary = "의견 남기기 API")
+    @Operation(
+            summary = "의견 남기기 API",
+            description = "의견을 남기는 경우 노션 DB에 저장되며, 슬랙으로 알림을 제공합니다."
+    )
     public CommonResponse<Void> sendFeedback(@RequestBody @Valid FeedbackRequest request) {
         userSettingUsecase.sendFeedback(request.feedback());
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,6 @@ notion:
   token: ${NOTION_API_TOKEN}
   database_id: ${NOTION_DATABASE_ID}
   version: ${NOTION_VERSION}
+
+slack:
+  webhook_url: ${SLACK_WEBHOOK_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,7 @@ springdoc:
     tags-sorter: alpha
     display-request-duration: true
 
+notion:
+  token: ${NOTION_API_TOKEN}
+  database_id: ${NOTION_DATABASE_ID}
+  version: ${NOTION_VERSION}


### PR DESCRIPTION
## Related issue 🛠
- closed #23 

## 작업 내용 💻

- 사용자 설정에서 알림 설정, 의견 남기기 기능을 구현했습니다.
- 사용자 설정은 조회 후 PATCH로 수정할 수 있게 null check해서 프론트에서 입력주는 값만 변동하도록 구현했습니다.
- 의견 남기기의 경우는 DB에 저장하기 보다는 사용성 높은 노션에 저장, 슬랙에 알림을 주는 방식으로 구현했습니다. 노션 DB에 저장할 때 동기식으로 저장하면 대기 시간이 너무 길어져서 비동기로 처리했습니다.
- 내 정보 조회 시 내가 받은 공감 수가 생략되어서 수정했습니다.

## 스크린샷 📷

- 노션에 저장되고 슬랙으로 알림이 오는 모습
<img width="764" alt="image" src="https://github.com/user-attachments/assets/9f5f92a5-2b44-4249-ad58-c7e79275c031" />
<img width="346" alt="image" src="https://github.com/user-attachments/assets/d1e09d32-eaa6-4da8-af97-f934d57397d2" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 스웨거 사용 편의성을 위해서 @Schema, @Operation 등을 적극적으로 사용해봤는데 어떤지 의견 남겨주시면 감사하겠슴둥



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 알림 설정 조회, 수정, 및 피드백 제출을 위한 사용자 설정 API가 추가되었습니다.
  - 사용자 피드백을 Notion 데이터베이스와 Slack으로 전송하는 기능이 도입되었습니다.
  - 사용자 알림 설정을 조회하고 수정할 수 있는 엔드포인트가 제공됩니다.

- **버그 수정**
  - 사용자 정보 응답에서 총 리액션 수 필드가 제거되었습니다.

- **문서화**
  - API 명세에 알림 설정 및 피드백 관련 설명과 예시가 추가되었습니다.

- **환경설정**
  - Notion 및 Slack 연동을 위한 환경 변수 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->