### PR TITLE
LNK-BE-8 이미지 업로더 구현, 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // S3
+    implementation("software.amazon.awssdk:s3:2.31.54")
 }
 
 tasks.named('test') {

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedDetailResponse.java
@@ -29,6 +29,9 @@ public record FeedDetailResponse(
         @Schema(description = "피드 미디어 목록")
         List<FeedMediaResponse> media,
 
+        @Schema(description = "함께한 사용자 수 (작성자 포함)", example = "8")
+        long linkedUserCount,
+
         @Schema(description = "함께한 사용자 목록")
         List<LinkedUserResponse> linkedUser
 ) {

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedUserListResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedUserListResponse.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.feed.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import leets.leenk.global.common.dto.CommonPageableResponse;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FeedUserListResponse(
+        @Schema(description = "사용자 목록")
+        List<FeedUserResponse> users,
+
+        @Schema(description = "페이징 정보")
+        CommonPageableResponse pageable
+) {
+}

--- a/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedUserResponse.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/response/FeedUserResponse.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.feed.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FeedUserResponse(
+        @Schema(description = "작성자 id", example = "1")
+        long userId,
+
+        @Schema(description = "프로필 이미지", example = "https://s3.example.com/profile_image.jpg")
+        String profileImage,
+
+        @Schema(description = "작성자 이름", example = "이강혁")
+        String name
+) {
+}

--- a/src/main/java/leets/leenk/domain/feed/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/feed/application/exception/ErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
 
-    FEED_NOT_FOUND(2200, HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다.");
+    FEED_NOT_FOUND(2200, HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다."),
+    SELF_REACTION(2202, HttpStatus.FORBIDDEN, "자신의 피드에 공감할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/feed/application/exception/SelfReactionNotAllowedException.java
+++ b/src/main/java/leets/leenk/domain/feed/application/exception/SelfReactionNotAllowedException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.feed.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class SelfReactionNotAllowedException extends BaseException {
+    public SelfReactionNotAllowedException() {
+        super(ErrorCode.SELF_REACTION);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
@@ -64,6 +64,7 @@ public class FeedMapper {
                 .totalReactionCount(feed.getTotalReactionCount())
                 .createdAt(feed.getCreateDate())
                 .media(toFeedMediaResponses(medias))
+                .linkedUserCount(linkedUsers.size())
                 .linkedUser(toLinkedUserResponses(linkedUsers, feed))
                 .build();
     }

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedUserMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedUserMapper.java
@@ -1,10 +1,15 @@
 package leets.leenk.domain.feed.application.mapper;
 
+import leets.leenk.domain.feed.application.dto.response.FeedUserListResponse;
 import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.global.common.dto.PageableMapperUtil;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class FeedUserMapper {
@@ -21,6 +26,17 @@ public class FeedUserMapper {
                 .userId(user.getId())
                 .profileImage(user.getProfileImage())
                 .name(user.getName())
+                .build();
+    }
+
+    public FeedUserListResponse toFeedUserListResponse(Slice<User> slice) {
+        List<FeedUserResponse> responses = slice.getContent().stream()
+                .map(this::toFeedUserResponse)
+                .toList();
+
+        return FeedUserListResponse.builder()
+                .users(responses)
+                .pageable(PageableMapperUtil.from(slice))
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedUserMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedUserMapper.java
@@ -1,17 +1,26 @@
 package leets.leenk.domain.feed.application.mapper;
 
+import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.stereotype.Component;
 
 @Component
-public class FeedLinkedUserMapper {
+public class FeedUserMapper {
 
     public LinkedUser toLinkedUser(User user, Feed feed) {
         return LinkedUser.builder()
                 .feed(feed)
                 .user(user)
+                .build();
+    }
+
+    public FeedUserResponse toFeedUserResponse(User user) {
+        return FeedUserResponse.builder()
+                .userId(user.getId())
+                .profileImage(user.getProfileImage())
+                .name(user.getName())
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -3,13 +3,10 @@ package leets.leenk.domain.feed.application.usecase;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
-import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
-import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
+import leets.leenk.domain.feed.application.dto.response.*;
 import leets.leenk.domain.feed.application.exception.SelfReactionNotAllowedException;
-import leets.leenk.domain.feed.application.mapper.FeedUserMapper;
 import leets.leenk.domain.feed.application.mapper.FeedMapper;
+import leets.leenk.domain.feed.application.mapper.FeedUserMapper;
 import leets.leenk.domain.feed.application.mapper.ReactionMapper;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
@@ -140,11 +137,20 @@ public class FeedUsecase {
     public void updateFeed(FeedUpdateRequest request) {
     }
 
+    @Transactional(readOnly = true)
     public List<FeedUserResponse> getAllUser() {
         List<User> users = userGetService.findAll();
 
         return users.stream()
                 .map(feedUserMapper::toFeedUserResponse)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public FeedUserListResponse getUsers(int pageNumber, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Slice<User> slice = userGetService.findAll(pageable);
+
+        return feedUserMapper.toFeedUserListResponse(slice);
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -114,7 +114,7 @@ public class FeedUsecase {
                         )
                 );
 
-        feedUpdateService.updateTotalReaction(feed, reaction, request.reactionCount());
+        feedUpdateService.updateTotalReaction(feed, reaction, feed.getUser(), request.reactionCount());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -5,9 +5,10 @@ import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
 import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
 import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
 import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
 import leets.leenk.domain.feed.application.exception.SelfReactionNotAllowedException;
-import leets.leenk.domain.feed.application.mapper.FeedLinkedUserMapper;
+import leets.leenk.domain.feed.application.mapper.FeedUserMapper;
 import leets.leenk.domain.feed.application.mapper.FeedMapper;
 import leets.leenk.domain.feed.application.mapper.ReactionMapper;
 import leets.leenk.domain.feed.domain.entity.Feed;
@@ -54,7 +55,7 @@ public class FeedUsecase {
 
     private final FeedMapper feedMapper;
     private final MediaMapper mediaMapper;
-    private final FeedLinkedUserMapper feedLinkedUserMapper;
+    private final FeedUserMapper feedUserMapper;
     private final ReactionMapper reactionMapper;
 
     @Transactional(readOnly = true)
@@ -100,7 +101,7 @@ public class FeedUsecase {
         users.add(author); // 중복 자동 제거
 
         return users.stream()
-                .map(user -> feedLinkedUserMapper.toLinkedUser(user, feed))
+                .map(user -> feedUserMapper.toLinkedUser(user, feed))
                 .toList();
     }
 
@@ -137,5 +138,13 @@ public class FeedUsecase {
     }
 
     public void updateFeed(FeedUpdateRequest request) {
+    }
+
+    public List<FeedUserResponse> getAllUser() {
+        List<User> users = userGetService.findAll();
+
+        return users.stream()
+                .map(feedUserMapper::toFeedUserResponse)
+                .toList();
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 
 public interface LinkedUserRepository extends JpaRepository<LinkedUser, Long> {
 
-    @Query("SELECT lu FROM LinkedUser lu JOIN FETCH lu.user WHERE lu.feed = :feed")
+    @Query("SELECT lu FROM LinkedUser lu JOIN FETCH lu.user WHERE lu.feed = :feed order by lu.user.name asc")
     List<LinkedUser> findAllByFeed(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/ReactionRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/ReactionRepository.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
     Optional<Reaction> findByFeedAndUser(Feed feed, User user);
 
-    @Query("SELECT r FROM Reaction r JOIN FETCH r.user WHERE r.feed = :feed")
+    @Query("SELECT r FROM Reaction r JOIN FETCH r.user WHERE r.feed = :feed order by r.reactionCount desc")
     List<Reaction> findAllByFeed(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
@@ -2,13 +2,15 @@ package leets.leenk.domain.feed.domain.service;
 
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.Reaction;
+import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.stereotype.Service;
 
 @Service
 public class FeedUpdateService {
 
-    public void updateTotalReaction(Feed feed, Reaction reaction, long reactionCount) {
+    public void updateTotalReaction(Feed feed, Reaction reaction, User user, long reactionCount) {
         feed.increaseTotalReactionCount(reactionCount);
         reaction.increaseReactionCount(reactionCount);
+        user.increaseTotalReactionCount(reactionCount);
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -10,6 +10,7 @@ import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
 import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
 import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
 import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
 import leets.leenk.domain.feed.application.usecase.FeedUsecase;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
@@ -80,4 +81,11 @@ public class FeedController {
         return CommonResponse.success(ResponseCode.UPDATE_FEED);
     }
 
+    @GetMapping("/users")
+    @Operation(summary = "함께한 사람 추가를 위한 사용자 조회")
+    public CommonResponse<List<FeedUserResponse>> getLinkedUsers() {
+        List<FeedUserResponse> response = feedUsecase.getAllUser();
+
+        return CommonResponse.success(ResponseCode.GET_ALL_USERS, response);
+    }
 }

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -8,10 +8,7 @@ import jakarta.validation.constraints.Positive;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
-import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
-import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
+import leets.leenk.domain.feed.application.dto.response.*;
 import leets.leenk.domain.feed.application.usecase.FeedUsecase;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
@@ -81,10 +78,19 @@ public class FeedController {
         return CommonResponse.success(ResponseCode.UPDATE_FEED);
     }
 
-    @GetMapping("/users")
+    @GetMapping("/users/all")
     @Operation(summary = "함께한 사람 추가를 위한 사용자 조회")
     public CommonResponse<List<FeedUserResponse>> getLinkedUsers() {
         List<FeedUserResponse> response = feedUsecase.getAllUser();
+
+        return CommonResponse.success(ResponseCode.GET_ALL_USERS, response);
+    }
+
+    @GetMapping("/users")
+    @Operation(summary = "함께한 사람 추가를 위한 사용자 무한 스크롤 조회", hidden = true)
+    public CommonResponse<FeedUserListResponse> getLinkedUsers(@RequestParam int pageNumber,
+                                                               @RequestParam int pageSize) {
+        FeedUserListResponse response = feedUsecase.getUsers(pageNumber, pageSize);
 
         return CommonResponse.success(ResponseCode.GET_ALL_USERS, response);
     }

--- a/src/main/java/leets/leenk/domain/feed/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/ResponseCode.java
@@ -15,7 +15,8 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPDATE_FEED(1203, HttpStatus.OK, "피드 수정에 성공했습니다."),
 
     CREATE_REACTION(1204, HttpStatus.OK, "피드 공감에 성공했습니다."),
-    GET_REACTED_USERS(1205, HttpStatus.OK, "피드에 공감한 사용자 조회에 성공했습니다.");
+    GET_REACTED_USERS(1205, HttpStatus.OK, "피드에 공감한 사용자 조회에 성공했습니다."),
+    GET_ALL_USERS(1206, HttpStatus.OK, "함께한 유저 추가를 위한 사용자 조회에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/feed/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/ResponseCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum ResponseCode implements ResponseCodeInterface {
 
     GET_ALL_FEED(1200, HttpStatus.OK, "전체 피드 조회에 성공했습니다."),
-    GET_FEED_DETAIL(1101, HttpStatus.OK, "피드 상세 조회에 성공했습니다."),
+    GET_FEED_DETAIL(1201, HttpStatus.OK, "피드 상세 조회에 성공했습니다."),
     UPLOAD_FEED(1202, HttpStatus.OK, "피드 업로드에 성공했습니다."),
     UPDATE_FEED(1203, HttpStatus.OK, "피드 수정에 성공했습니다."),
 

--- a/src/main/java/leets/leenk/domain/media/application/dto/response/MediaUrlResponse.java
+++ b/src/main/java/leets/leenk/domain/media/application/dto/response/MediaUrlResponse.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MediaUrlResponse(
         @Schema(description = "파일 이름", example = "image.jpg")
         String fileName,
+
         @Schema(description = "미디어 S3 URL", example = "https://s3.example.com/image.jpg")
         String mediaUrl
 ) {

--- a/src/main/java/leets/leenk/domain/media/application/dto/response/MediaUrlResponse.java
+++ b/src/main/java/leets/leenk/domain/media/application/dto/response/MediaUrlResponse.java
@@ -1,0 +1,11 @@
+package leets.leenk.domain.media.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record MediaUrlResponse(
+        @Schema(description = "파일 이름", example = "image.jpg")
+        String fileName,
+        @Schema(description = "미디어 S3 URL", example = "https://s3.example.com/image.jpg")
+        String mediaUrl
+) {
+}

--- a/src/main/java/leets/leenk/domain/media/application/usecase/MediaUsecase.java
+++ b/src/main/java/leets/leenk/domain/media/application/usecase/MediaUsecase.java
@@ -1,0 +1,21 @@
+package leets.leenk.domain.media.application.usecase;
+
+import leets.leenk.domain.media.application.dto.response.MediaUrlResponse;
+import leets.leenk.domain.media.domain.service.S3PresignedUrlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MediaUsecase {
+
+    private final S3PresignedUrlService s3PresignedUrlService;
+
+    public List<MediaUrlResponse> getUrl(List<String> fileName) {
+        return fileName.stream()
+                .map(s3PresignedUrlService::generateUrl)
+                .toList();
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
@@ -1,0 +1,50 @@
+package leets.leenk.domain.media.domain.service;
+
+import leets.leenk.domain.media.application.dto.response.MediaUrlResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3PresignedUrlService {
+
+    private final S3Presigner s3Presigner;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public MediaUrlResponse generateUrl(String fileName) {
+        String key = generateKey(fileName);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        PutObjectPresignRequest request = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(5))
+                .putObjectRequest(putObjectRequest)
+                .build();
+
+        PresignedPutObjectRequest presignedUrlRequest = s3Presigner.presignPutObject(request);
+
+        String putUrl = presignedUrlRequest.url().toString();
+
+        return new MediaUrlResponse(fileName, putUrl);
+    }
+
+    private String generateKey(String fileName) {
+        String key = UUID.randomUUID().toString();
+        String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+
+        return key + "." + extension;
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
@@ -21,6 +21,9 @@ public class S3PresignedUrlService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    /*
+    차후 CDN 캐싱도 고려
+     */
     public MediaUrlResponse generateUrl(String fileName) {
         String key = generateKey(fileName);
 

--- a/src/main/java/leets/leenk/domain/media/presentation/MediaController.java
+++ b/src/main/java/leets/leenk/domain/media/presentation/MediaController.java
@@ -1,0 +1,31 @@
+package leets.leenk.domain.media.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import leets.leenk.domain.media.application.dto.response.MediaUrlResponse;
+import leets.leenk.domain.media.application.usecase.MediaUsecase;
+import leets.leenk.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "MEDIA")
+@RestController
+@RequestMapping("/medias")
+@RequiredArgsConstructor
+public class MediaController {
+
+    private final MediaUsecase mediaUsecase;
+
+    @GetMapping
+    @Operation(summary = "파일 업로드를 위한 presigned url을 요청하는 API 입니다.")
+    public CommonResponse<List<MediaUrlResponse>> getUrl(@RequestParam List<String> fileName) {
+        List<MediaUrlResponse> response = mediaUsecase.getUrl(fileName);
+
+        return CommonResponse.success(ResponseCode.GET_MEDIA_URL, response);
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/media/presentation/ResponseCode.java
@@ -1,0 +1,18 @@
+package leets.leenk.domain.media.presentation;
+
+import leets.leenk.global.common.response.ResponseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode implements ResponseCodeInterface {
+
+    GET_MEDIA_URL(1500, HttpStatus.OK, "프리사인드 url 발급에 성공했습니다.");
+
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -68,6 +68,10 @@ public class User extends BaseEntity {
         this.mbti = mbti;
     }
 
+    public void increaseTotalReactionCount(long reactionCount) {
+        this.totalReactionCount += reactionCount;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package leets.leenk.domain.user.domain.repository;
 
 import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByIdIn(List<Long> userIds);
 
     List<User> findAllByOrderByName();
+
+    Slice<User> findAllByOrderByName(Pageable pageable);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     List<User> findAllByIdIn(List<Long> userIds);
+
+    List<User> findAllByOrderByName();
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
@@ -27,4 +27,8 @@ public class UserGetService {
     public List<User> findAll(List<Long> userIds) {
         return userRepository.findAllByIdIn(userIds);
     }
+
+    public List<User> findAll() {
+        return userRepository.findAllByOrderByName();
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/UserGetService.java
@@ -4,6 +4,8 @@ import leets.leenk.domain.user.application.exception.UserNotFoundException;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -30,5 +32,9 @@ public class UserGetService {
 
     public List<User> findAll() {
         return userRepository.findAllByOrderByName();
+    }
+
+    public Slice<User> findAll(Pageable pageable) {
+        return userRepository.findAllByOrderByName(pageable);
     }
 }

--- a/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
@@ -2,7 +2,6 @@ package leets.leenk.global.common.exception;
 
 import leets.leenk.global.common.exception.response.ValidErrorResponse;
 import leets.leenk.global.common.response.CommonResponse;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -12,7 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.List;
-@Slf4j
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -20,7 +19,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleException(BaseException e) {
         ErrorCodeInterface errorCode = e.getErrorCode();
         String errorMessage = e.getMessage();
-        log.warn("구체로그: ", e);
         CommonResponse<Void> body = CommonResponse.error(errorCode, errorMessage);
 
         return ResponseEntity
@@ -31,7 +29,6 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<List<ValidErrorResponse>>> handleValidation(MethodArgumentNotValidException e) {
         ErrorCode errorCode = ErrorCode.INVALID_ARGUMENT;
-        log.warn("구체로그: ", e);
 
         List<ValidErrorResponse> errors = e.getBindingResult()
                 .getFieldErrors().stream()
@@ -53,7 +50,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
         ErrorCode errorCode = ErrorCode.INVALID_ARGUMENT;
         CommonResponse<Void> body = CommonResponse.error(errorCode);
-        log.warn("구체로그: ", e);
 
 
         return ResponseEntity
@@ -75,7 +71,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
         ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
         CommonResponse<Void> body = CommonResponse.error(errorCode);
-        log.warn("구체로그: ", e);
 
 
         return ResponseEntity
@@ -108,7 +103,6 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleAll(Exception e) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         CommonResponse<Void> body = CommonResponse.error(errorCode, e.getMessage());
-        log.warn("구체로그: ", e);
 
 
         return ResponseEntity

--- a/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/leets/leenk/global/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package leets.leenk.global.common.exception;
 
 import leets.leenk.global.common.exception.response.ValidErrorResponse;
 import leets.leenk.global.common.response.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.List;
-
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -19,6 +20,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleException(BaseException e) {
         ErrorCodeInterface errorCode = e.getErrorCode();
         String errorMessage = e.getMessage();
+        log.warn("구체로그: ", e);
         CommonResponse<Void> body = CommonResponse.error(errorCode, errorMessage);
 
         return ResponseEntity
@@ -29,6 +31,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<List<ValidErrorResponse>>> handleValidation(MethodArgumentNotValidException e) {
         ErrorCode errorCode = ErrorCode.INVALID_ARGUMENT;
+        log.warn("구체로그: ", e);
+
         List<ValidErrorResponse> errors = e.getBindingResult()
                 .getFieldErrors().stream()
                 .map(fe -> ValidErrorResponse.of(
@@ -46,9 +50,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<CommonResponse<Void>> handleIllegalArgument() {
+    public ResponseEntity<CommonResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
         ErrorCode errorCode = ErrorCode.INVALID_ARGUMENT;
         CommonResponse<Void> body = CommonResponse.error(errorCode);
+        log.warn("구체로그: ", e);
+
 
         return ResponseEntity
                 .status(errorCode.getStatus())
@@ -69,6 +75,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
         ErrorCode errorCode = ErrorCode.METHOD_NOT_ALLOWED;
         CommonResponse<Void> body = CommonResponse.error(errorCode);
+        log.warn("구체로그: ", e);
+
 
         return ResponseEntity
                 .status(e.getStatusCode().value())
@@ -78,9 +86,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<CommonResponse<Void>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
         Throwable cause = ex.getMostSpecificCause();
+
         if (cause instanceof BaseException be) {
             ErrorCodeInterface errorCode = be.getErrorCode();
-            CommonResponse<Void> body = CommonResponse.error(errorCode);
+            CommonResponse<Void> body = CommonResponse.error(errorCode, ex.getMessage());
 
             return ResponseEntity
                     .status(errorCode.getStatus())
@@ -88,7 +97,7 @@ public class GlobalExceptionHandler {
         }
 
         ErrorCode errorCode = ErrorCode.JSON_PARSE_ERROR;
-        CommonResponse<Void> body = CommonResponse.error(errorCode);
+        CommonResponse<Void> body = CommonResponse.error(errorCode, ex.getMessage());
 
         return ResponseEntity
                 .status(errorCode.getStatus())
@@ -99,6 +108,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonResponse<Void>> handleAll(Exception e) {
         ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         CommonResponse<Void> body = CommonResponse.error(errorCode, e.getMessage());
+        log.warn("구체로그: ", e);
+
 
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/leets/leenk/global/config/AwsS3Config.java
+++ b/src/main/java/leets/leenk/global/config/AwsS3Config.java
@@ -18,6 +18,7 @@ public class AwsS3Config {
 
     @Value("${cloud.aws.credentials.secret-key}")
     private String accessSecret;
+
     @Value("${cloud.aws.region.static}")
     private String region;
 

--- a/src/main/java/leets/leenk/global/config/AwsS3Config.java
+++ b/src/main/java/leets/leenk/global/config/AwsS3Config.java
@@ -1,0 +1,33 @@
+package leets.leenk.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class AwsS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String accessSecret;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,3 +23,14 @@ auth:
     kakao:
       kakao_grant_type: ${KAKAO_GRANT_TYPE}
       kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}
+
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -24,3 +24,13 @@ auth:
       kakao_grant_type: ${KAKAO_GRANT_TYPE}
       kakao_grant_type_name: ${KAKAO_GRANT_TYPE_NAME}
 
+cloud:
+  aws:
+    s3:
+      bucket: ${S3_BUCKET_NAME}
+    credentials:
+      access-key: ${S3_ACCESS_KEY}
+      secret-key: ${S3_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+


### PR DESCRIPTION
## Related issue 🛠
- closed #22 

## 작업 내용 💻

- S3 Presigned Url을 발급하는 API를 구현했습니다
- 조회 API의 정렬 방식을 요구사항에 맞게 수정했습니다 (태그된 사용자 조회: 가나다순, 공감한 사람 조회: 공감 개수 내림차순, 태그할 사용자 전체 조회: 가나다순)
- 피드를 업로드할 때 태그할 수 있는 사용자 조회 API를 만들었습니다. 검색 편의성을 위해 전체 사용자를 가져오는 방식으로 구현을 했고, 차후 사용자가 많아져 로딩 속도에 대한 피드백이 들어올 경우를 대비대 무한 스크롤 API도 구현해뒀습니다. (가려둔 상황)
- 자신이 업로드한 피드에 공감하지 못하게 예외처리 해뒀습니다.
- 프론트 요구사항에 맞게 태그된 인원 수도 함께 반환하도록 했습니다

## 스크린샷 📷

- 이미지 업로드 및 조회 테스트
<img width="573" alt="image" src="https://github.com/user-attachments/assets/61b32f95-5be3-4bac-8edc-25419ac9b0a5" />

<img width="499" alt="image" src="https://github.com/user-attachments/assets/598a10cb-46b0-4e1b-82dd-e14216918c6d" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 미디어 파일 업로드를 위한 AWS S3 presigned URL 발급 API가 추가되었습니다.
  - 피드에 함께한 유저(공동작업자) 목록 및 페이징 조회 API가 추가되었습니다.
  - 피드 상세 응답에 함께한 유저 수(linkedUserCount) 정보가 포함됩니다.

- **버그 수정**
  - 예외 응답에 상세 메시지가 포함되어, 에러 발생 시 더 많은 정보를 제공합니다.

- **개선 및 변경**
  - 사용자가 자신의 피드에 공감(리액션)하는 것을 방지하는 검증이 추가되었습니다.
  - 피드, 리액션, 유저의 리액션 카운트 집계가 개선되었습니다.
  - 피드 및 유저 목록 조회 시 이름 기준 정렬 및 페이징이 적용됩니다.

- **설정**
  - AWS S3 연동을 위한 환경설정 및 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->