### PR TITLE
LNK-BE-15 피드 신고, 유저 차단 기능 구현

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedReportRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedReportRequest.java
@@ -1,0 +1,11 @@
+package leets.leenk.domain.feed.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record FeedReportRequest(
+        @NotBlank
+        @Size(max = 100)
+        String report
+) {
+}

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.feed.application.usecase;
 
+import leets.leenk.domain.feed.application.dto.request.FeedReportRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
@@ -18,6 +19,8 @@ import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.service.MediaGetService;
 import leets.leenk.domain.media.domain.service.MediaSaveService;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.service.NotionDatabaseService;
+import leets.leenk.domain.user.domain.service.SlackWebhookService;
 import leets.leenk.domain.user.domain.service.user.UserGetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -37,6 +40,8 @@ import java.util.stream.Collectors;
 public class FeedUsecase {
 
     private final UserGetService userGetService;
+    private final SlackWebhookService slackWebhookService;
+    private final NotionDatabaseService notionDatabaseService;
 
     private final FeedGetService feedGetService;
     private final FeedSaveService feedSaveService;
@@ -203,5 +208,14 @@ public class FeedUsecase {
         }
 
         feedDeleteService.delete(feed);
+    }
+
+    @Transactional(readOnly = true)
+    public void reportFeed(long userId, long feedId, FeedReportRequest request) {
+        User user = userGetService.findById(userId);
+        Feed feed = feedGetService.findById(feedId);
+
+        notionDatabaseService.sendFeedReport(request.report(), user.getId(), feed.getId());
+        slackWebhookService.sendFeedReport(request.report());
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/FeedRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/FeedRepository.java
@@ -7,12 +7,13 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 
-    @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL")
-    Slice<Feed> findAllByDeletedAtIsNullWithUser(Pageable pageable);
+    @Query("SELECT f FROM Feed f JOIN FETCH f.user u WHERE f.deletedAt IS NULL AND u.id NOT IN :blockedUserIds")
+    Slice<Feed> findAllByDeletedAtIsNullWithUser(Pageable pageable, List<Long> blockedUserIds);
 
     @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL AND f.user = :user")
     Slice<Feed> findAllByUserAndDeletedAtIsNull(User user, Pageable pageable);

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedGetService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedGetService.java
@@ -4,10 +4,13 @@ import leets.leenk.domain.feed.application.exception.FeedNotFoundException;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.repository.FeedRepository;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserBlock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,8 +23,13 @@ public class FeedGetService {
                 .orElseThrow(FeedNotFoundException::new);
     }
 
-    public Slice<Feed> findAll(Pageable pageable) {
-        return feedRepository.findAllByDeletedAtIsNullWithUser(pageable);
+    public Slice<Feed> findAll(Pageable pageable, List<UserBlock> blockedUser) {
+        List<Long> blockedUserIds = blockedUser.stream()
+                .map(UserBlock::getBlocked)
+                .map(User::getId)
+                .toList();
+
+        return feedRepository.findAllByDeletedAtIsNullWithUser(pageable, blockedUserIds);
     }
 
     public Slice<Feed> findAllByUser(User user, Pageable pageable) {

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import leets.leenk.domain.feed.application.dto.request.FeedReportRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
@@ -125,6 +126,7 @@ public class FeedController {
 
         return CommonResponse.success(ResponseCode.GET_OTHER_LINKED_FEEDS, response);
     }
+
     @GetMapping("/users/all")
     @Operation(summary = "함께한 사람 추가를 위한 사용자 조회")
     public CommonResponse<List<FeedUserResponse>> getLinkedUsers() {
@@ -140,6 +142,16 @@ public class FeedController {
         FeedUserListResponse response = feedUsecase.getUsers(pageNumber, pageSize);
 
         return CommonResponse.success(ResponseCode.GET_ALL_USERS, response);
+    }
+
+    @PostMapping("/{feedId}/reports")
+    @Operation(summary = "피드 신고 API", description = "의견 남기기와 동일하게 노션 db에 신고 내용이 저장되고, 슬랙으로 알림이 전송됩니다.")
+    public CommonResponse<Void> reportFeed(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                           @PathVariable @Positive long feedId,
+                                           @RequestBody @Valid FeedReportRequest request) {
+        feedUsecase.reportFeed(userId, feedId, request);
+
+        return CommonResponse.success(ResponseCode.REPORT_FEED);
     }
 
     @DeleteMapping("/{feedId}")

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -28,9 +28,10 @@ public class FeedController {
 
     @GetMapping
     @Operation(summary = "피드 조회 API - 무한 스크롤")
-    public CommonResponse<FeedListResponse> getFeeds(@RequestParam int pageNumber,
+    public CommonResponse<FeedListResponse> getFeeds(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                     @RequestParam int pageNumber,
                                                      @RequestParam int pageSize) {
-        FeedListResponse response = feedUsecase.getFeeds(pageNumber, pageSize);
+        FeedListResponse response = feedUsecase.getFeeds(userId, pageNumber, pageSize);
 
         return CommonResponse.success(ResponseCode.GET_ALL_FEED, response);
     }

--- a/src/main/java/leets/leenk/domain/feed/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/ResponseCode.java
@@ -22,7 +22,8 @@ public enum ResponseCode implements ResponseCodeInterface {
     GET_OTHER_LINKED_FEEDS(1209, HttpStatus.OK, "다른 사용자가 링크된 피드 조회에 성공했습니다."),
     GET_ALL_USERS(1210, HttpStatus.OK, "함께한 유저 추가를 위한 사용자 조회에 성공했습니다."),
 
-    DELETE_FEED(1211, HttpStatus.OK, "피드 삭제에 성공했습니다.");
+    DELETE_FEED(1211, HttpStatus.OK, "피드 삭제에 성공했습니다."),
+    REPORT_FEED(1212, HttpStatus.OK, "피드 신고에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/ErrorCode.java
@@ -13,7 +13,9 @@ public enum ErrorCode implements ErrorCodeInterface {
     USER_NOT_FOUND(2100, HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다."),
     USER_SETTING_NOT_FOUND(2101, HttpStatus.NOT_FOUND, "존재하지 않는 사용자 설정입니다."),
     USER_ALREADY_Leave(2102, HttpStatus.BAD_REQUEST, "이미 탈퇴한 사용자입니다."),
-    USER_BACKUP_INFO_ERROR(2103, HttpStatus.NOT_FOUND, "백업 정보를 찾을 수 없어 계정을 복구할 수 없습니다.");
+    USER_BACKUP_INFO_ERROR(2103, HttpStatus.NOT_FOUND, "백업 정보를 찾을 수 없어 계정을 복구할 수 없습니다."),
+    USER_ALREADY_BLOCKED(2104, HttpStatus.BAD_REQUEST, "이미 차단한 사용자입니다."),
+    SELF_BLOCK_NOT_ALLOWED(2105, HttpStatus.BAD_REQUEST, "자기 자신을 차단할 수 없습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/application/exception/SelfBlockNotAllowedException.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/SelfBlockNotAllowedException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class SelfBlockNotAllowedException extends BaseException {
+    public SelfBlockNotAllowedException() {
+        super(ErrorCode.SELF_BLOCK_NOT_ALLOWED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/exception/UserAlreadyBlockedException.java
+++ b/src/main/java/leets/leenk/domain/user/application/exception/UserAlreadyBlockedException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class UserAlreadyBlockedException extends BaseException {
+    public UserAlreadyBlockedException() {
+        super(ErrorCode.USER_ALREADY_BLOCKED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/mapper/UserBlockMapper.java
+++ b/src/main/java/leets/leenk/domain/user/application/mapper/UserBlockMapper.java
@@ -1,0 +1,16 @@
+package leets.leenk.domain.user.application.mapper;
+
+import leets.leenk.domain.user.domain.entity.UserBlock;
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserBlockMapper {
+
+    public UserBlock toUserBlock(User blocker, User blocked) {
+        return UserBlock.builder()
+                .blocker(blocker)
+                .blocked(blocked)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -2,13 +2,15 @@ package leets.leenk.domain.user.application.usecase;
 
 import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
+import leets.leenk.domain.user.application.exception.SelfBlockNotAllowedException;
+import leets.leenk.domain.user.application.exception.UserAlreadyBlockedException;
 import leets.leenk.domain.user.application.exception.UserAlreadyLeaveException;
 import leets.leenk.domain.user.application.mapper.UserBackupInfoMapper;
 import leets.leenk.domain.user.application.mapper.UserBlockMapper;
 import leets.leenk.domain.user.application.mapper.UserMapper;
-import leets.leenk.domain.user.domain.entity.UserBlock;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserBackupInfo;
+import leets.leenk.domain.user.domain.entity.UserBlock;
 import leets.leenk.domain.user.domain.service.blockuser.UserBlockService;
 import leets.leenk.domain.user.domain.service.user.UserDeleteService;
 import leets.leenk.domain.user.domain.service.user.UserGetService;
@@ -93,8 +95,16 @@ public class UserUsecase {
 
     @Transactional
     public void blockUser(long userId, long blockedUserId) {
+        if (userId == blockedUserId) {
+            throw new SelfBlockNotAllowedException();
+        }
+
         User user = userGetService.findById(userId);
         User blockedUser = userGetService.findById(blockedUserId);
+
+        if (userBlockService.isAlreadyBlocked(user, blockedUser)) {
+            throw new UserAlreadyBlockedException();
+        }
 
         UserBlock blockUser = userBlockMapper.toUserBlock(user, blockedUser);
         userBlockService.blockUser(blockUser);

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -4,9 +4,12 @@ import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.exception.UserAlreadyLeaveException;
 import leets.leenk.domain.user.application.mapper.UserBackupInfoMapper;
+import leets.leenk.domain.user.application.mapper.UserBlockMapper;
 import leets.leenk.domain.user.application.mapper.UserMapper;
+import leets.leenk.domain.user.domain.entity.UserBlock;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserBackupInfo;
+import leets.leenk.domain.user.domain.service.blockuser.UserBlockService;
 import leets.leenk.domain.user.domain.service.user.UserDeleteService;
 import leets.leenk.domain.user.domain.service.user.UserGetService;
 import leets.leenk.domain.user.domain.service.user.UserUpdateService;
@@ -28,6 +31,9 @@ public class UserUsecase {
     private final UserBackupInfoMapper userBackupInfoMapper;
     private final UserBackupInfoSaveService userBackupInfoSaveService;
     private final UserBackupInfoGetService userBackupInfoGetService;
+
+    private final UserBlockMapper userBlockMapper;
+    private final UserBlockService userBlockService;
 
     @Transactional
     public void completeProfile(long userId, RegisterRequest request) {
@@ -83,5 +89,14 @@ public class UserUsecase {
 
         userBackupInfoSaveService.save(userBackupInfo);
         userDeleteService.leave(user);
+    }
+
+    @Transactional
+    public void blockUser(long userId, long blockedUserId) {
+        User user = userGetService.findById(userId);
+        User blockedUser = userGetService.findById(blockedUserId);
+
+        UserBlock blockUser = userBlockMapper.toUserBlock(user, blockedUser);
+        userBlockService.blockUser(blockUser);
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/entity/UserBlock.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/UserBlock.java
@@ -1,0 +1,30 @@
+package leets.leenk.domain.user.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Entity
+@SuperBuilder
+@Table(
+        name = "user_blocks",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"blocker_id", "blocked_id"})
+        })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBlock {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "blocker_id", nullable = false)
+    private User blocker;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "blocked_id", nullable = false)
+    private User blocked;
+}

--- a/src/main/java/leets/leenk/domain/user/domain/repository/BlockedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/BlockedUserRepository.java
@@ -1,0 +1,11 @@
+package leets.leenk.domain.user.domain.repository;
+
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BlockedUserRepository extends JpaRepository<UserBlock, Long> {
+    List<UserBlock> findAllByBlocker(User blocker);
+}

--- a/src/main/java/leets/leenk/domain/user/domain/repository/BlockedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/BlockedUserRepository.java
@@ -5,7 +5,10 @@ import leets.leenk.domain.user.domain.entity.UserBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BlockedUserRepository extends JpaRepository<UserBlock, Long> {
     List<UserBlock> findAllByBlocker(User blocker);
+
+    Optional<UserBlock> findAllByBlockerAndBlocked(User user, User blockedUser);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/repository/BlockedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/BlockedUserRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface BlockedUserRepository extends JpaRepository<UserBlock, Long> {
     List<UserBlock> findAllByBlocker(User blocker);
 
-    Optional<UserBlock> findAllByBlockerAndBlocked(User user, User blockedUser);
+    Optional<UserBlock> findByBlockerAndBlocked(User blocker, User blocked);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/NotionDatabaseService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/NotionDatabaseService.java
@@ -20,8 +20,11 @@ public class NotionDatabaseService {
     @Value("${notion.token}")
     private String NOTION_TOKEN;
 
-    @Value("${notion.database_id}")
-    private String DATABASE_ID;
+    @Value("${notion.feedback_database_id}")
+    private String FEEDBACK_DATABASE_ID;
+
+    @Value("${notion.report_database_id}")
+    private String REPORT_DATABASE_ID;
 
     @Value("${notion.version}")
     private String NOTION_VERSION;
@@ -35,7 +38,7 @@ public class NotionDatabaseService {
         Map<String, Object> requestBody = Map.of(
                 "parent", Map.of(
                         "type", "database_id",
-                        "database_id", DATABASE_ID
+                        "database_id", FEEDBACK_DATABASE_ID
                 ),
                 "properties", Map.of(
                         "피드백", Map.of(
@@ -45,6 +48,47 @@ public class NotionDatabaseService {
                         ),
                         "날짜", Map.of(
                                 "date", Map.of("start", today)
+                        )
+                )
+        );
+
+        notionRestClient.post()
+                .uri(NOTION_INSERT_URI)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + NOTION_TOKEN)
+                .header("Notion-Version", NOTION_VERSION)
+                .header(HttpHeaders.CONTENT_TYPE, "application/json")
+                .body(requestBody)
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    @Async
+    public void sendFeedReport(String report, long userId, long feedId) {
+        String today = LocalDate.now().toString();
+
+        Map<String, Object> requestBody = Map.of(
+                "parent", Map.of(
+                        "type", "database_id",
+                        "database_id", REPORT_DATABASE_ID
+                ),
+                "properties", Map.of(
+                        "사유", Map.of(
+                                "title", List.of(
+                                        Map.of("text", Map.of("content", report))
+                                )
+                        ),
+                        "신고 날짜", Map.of(
+                                "date", Map.of("start", today)
+                        ),
+                        "피드 id", Map.of(
+                                "rich_text", List.of(
+                                        Map.of("text", Map.of("content", String.valueOf(feedId)))
+                                )
+                        ),
+                        "사용자 id", Map.of(
+                                "rich_text", List.of(
+                                        Map.of("text", Map.of("content", String.valueOf(userId)))
+                                )
                         )
                 )
         );

--- a/src/main/java/leets/leenk/domain/user/domain/service/SlackWebhookService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/SlackWebhookService.java
@@ -26,4 +26,15 @@ public class SlackWebhookService {
                 .retrieve()
                 .toBodilessEntity();
     }
+
+    public void sendFeedReport(String report) {
+        String formatted = "*[피드 신고]*\n```" + report + "```";
+
+        slackRestClient.post()
+                .uri(webhookUrl)
+                .header("Content-Type", "application/json")
+                .body(Map.of("text", formatted))
+                .retrieve()
+                .toBodilessEntity();
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/blockuser/UserBlockService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/blockuser/UserBlockService.java
@@ -1,0 +1,24 @@
+package leets.leenk.domain.user.domain.service.blockuser;
+
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserBlock;
+import leets.leenk.domain.user.domain.repository.BlockedUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserBlockService {
+
+    private final BlockedUserRepository blockedUserRepository;
+
+    public void blockUser(UserBlock userBlock) {
+        blockedUserRepository.save(userBlock);
+    }
+
+    public List<UserBlock> findAllByBlocker(User blocker) {
+        return blockedUserRepository.findAllByBlocker(blocker);
+    }
+}

--- a/src/main/java/leets/leenk/domain/user/domain/service/blockuser/UserBlockService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/blockuser/UserBlockService.java
@@ -23,6 +23,6 @@ public class UserBlockService {
     }
 
     public boolean isAlreadyBlocked(User user, User blockedUser) {
-        return blockedUserRepository.findAllByBlockerAndBlocked(user, blockedUser).isPresent();
+        return blockedUserRepository.findByBlockerAndBlocked(user, blockedUser).isPresent();
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/blockuser/UserBlockService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/blockuser/UserBlockService.java
@@ -21,4 +21,8 @@ public class UserBlockService {
     public List<UserBlock> findAllByBlocker(User blocker) {
         return blockedUserRepository.findAllByBlocker(blocker);
     }
+
+    public boolean isAlreadyBlocked(User user, User blockedUser) {
+        return blockedUserRepository.findAllByBlockerAndBlocked(user, blockedUser).isPresent();
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -17,6 +17,7 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다."),
     COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
     DELETE_USER(1107, HttpStatus.OK, "회원 탈퇴에 성공했습니다."),
+    BLOCK_USER(1108, HttpStatus.OK, "사용자 차단에 성공했습니다."),
 
     GET_NOTIFICATION_SETTING(1110, HttpStatus.OK, "알림 설정 조회에 성공했습니다."),
     UPDATE_NOTIFICATION_SETTING(1111, HttpStatus.OK, "알림 설정 수정에 성공했습니다."),

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -83,6 +83,15 @@ public class UserController {
         return CommonResponse.success(UPDATE_MBTI);
     }
 
+    @PostMapping("/{userId}/block")
+    @Operation(summary = "유저 차단하기 API")
+    public CommonResponse<Void> blockUser(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                          @PathVariable long blockedUserId) {
+        userUsecase.blockUser(userId, blockedUserId);
+
+        return CommonResponse.success(BLOCK_USER);
+    }
+
     @DeleteMapping("/me")
     @Operation(summary = "회원 탈퇴 API")
     public CommonResponse<Void> deleteAccount(@Parameter(hidden = true) @CurrentUserId Long userId) {

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -86,7 +86,7 @@ public class UserController {
     @PostMapping("/{userId}/block")
     @Operation(summary = "유저 차단하기 API")
     public CommonResponse<Void> blockUser(@Parameter(hidden = true) @CurrentUserId Long userId,
-                                          @PathVariable long blockedUserId) {
+                                          @PathVariable("userId") long blockedUserId) {
         userUsecase.blockUser(userId, blockedUserId);
 
         return CommonResponse.success(BLOCK_USER);

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -1,37 +1,18 @@
 package leets.leenk.domain.user.presentation;
 
-import static leets.leenk.domain.user.presentation.ResponseCode.COMPLETE_PROFILE;
-import static leets.leenk.domain.user.presentation.ResponseCode.DELETE_USER;
-import static leets.leenk.domain.user.presentation.ResponseCode.GET_MY_INFO;
-import static leets.leenk.domain.user.presentation.ResponseCode.GET_USER_INFO;
-import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_AGREEMENT;
-import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_INTRODUCTION;
-import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_KAKAO_TALK_ID;
-import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_MBTI;
-import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_PROFILE_IMAGE;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import leets.leenk.domain.user.application.dto.request.AgreementRequest;
-import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
-import leets.leenk.domain.user.application.dto.request.KakaoTalkIdRequest;
-import leets.leenk.domain.user.application.dto.request.MbtiRequest;
-import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
-import leets.leenk.domain.user.application.dto.request.RegisterRequest;
+import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.usecase.UserUsecase;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import static leets.leenk.domain.user.presentation.ResponseCode.*;
 
 @Tag(name = "USER")
 @RestController

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,8 @@ springdoc:
 
 notion:
   token: ${NOTION_API_TOKEN}
-  database_id: ${NOTION_DATABASE_ID}
+  feedback_database_id: ${NOTION_FEEDBACK_DATABASE_ID}
+  report_database_id: ${NOTION_REPORT_DATABASE_ID}
   version: ${NOTION_VERSION}
 
 slack:


### PR DESCRIPTION
## Related issue 🛠
- closed #32 

## 작업 내용 💻

- 피드 신고, 유저 차단 기능을 구현했습니다
- 피드 신고의 경우는 의견 남기기와 동일하게 노션 DB에 저장 + 슬랙 알림으로 구현했습니다. 유저와 피드를 각각 조회해서 id를 노션 DB에 저장하도록 했습니다
- 유저 차단의 경우는 차단할 유저 id를 받아서 RDB에 별도로 저장하게 했습니다. 그 후 피드 전체 조회를 할 때 차단 유저 목록을 확인해서 피드를 필터링 하게 구현했습니다

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 유저 차단 + 피드 필터링은 우선 빠르게 구현을 해서 후에 쿼리 최적화가 필요할 듯 합니다. 지금도 크게 속도가 늦어지진 않았는데, 맘에 들진 않아서 추후에 리팩토링 진행하겠습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자를 차단하는 기능이 추가되었습니다.
  * 피드 신고 기능이 추가되었습니다.
  * 피드 목록에서 차단한 사용자의 피드가 제외됩니다.

* **버그 수정**
  * 없음

* **기타**
  * 피드 신고 및 피드백 처리를 위한 Notion, Slack 연동이 추가되었습니다.
  * 응답 코드에 사용자 차단 및 피드 신고 관련 항목이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->