### PR TITLE
LNK-BE-13 알림 리팩토링

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -18,6 +18,7 @@ import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.service.MediaGetService;
 import leets.leenk.domain.media.domain.service.MediaSaveService;
+import leets.leenk.domain.notification.application.usecase.NotificationUsecase;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserBlock;
 import leets.leenk.domain.user.domain.service.NotionDatabaseService;
@@ -59,6 +60,8 @@ public class FeedUsecase {
 
     private final ReactionGetService reactionGetService;
     private final ReactionSaveService reactionSaveService;
+
+    private final NotificationUsecase notificationUsecase;
 
     private final FeedMapper feedMapper;
     private final MediaMapper mediaMapper;
@@ -104,6 +107,9 @@ public class FeedUsecase {
 
         List<LinkedUser> linkedUsers = getLinkedUsers(author, request.userId(), feed);
         linkedUserSaveService.saveAll(linkedUsers);
+
+        notificationUsecase.saveNewFeedNotification(feed);
+        notificationUsecase.saveTagNotification(feed, linkedUsers);
     }
 
     private List<LinkedUser> getLinkedUsers(User author, List<Long> userIds, Feed feed) {
@@ -129,6 +135,8 @@ public class FeedUsecase {
                 );
 
         feedUpdateService.updateTotalReaction(feed, reaction, feed.getUser(), request.reactionCount());
+
+        notificationUsecase.saveFirstReactionNotification(reaction);
     }
 
     private void validateReaction(Feed feed, User user) {

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -134,9 +134,14 @@ public class FeedUsecase {
                         )
                 );
 
+        long previousReactionCount = reaction.getReactionCount();
+
         feedUpdateService.updateTotalReaction(feed, reaction, feed.getUser(), request.reactionCount());
 
         notificationUsecase.saveFirstReactionNotification(reaction);
+
+        long updatedReactionCount = previousReactionCount + request.reactionCount();
+        notifyIfReachedReactionMilestone(previousReactionCount, updatedReactionCount, feed);
     }
 
     private void validateReaction(Feed feed, User user) {
@@ -231,5 +236,15 @@ public class FeedUsecase {
 
         notionDatabaseService.sendFeedReport(request.report(), user.getId(), feed.getId());
         slackWebhookService.sendFeedReport(request.report());
+    }
+
+    private void notifyIfReachedReactionMilestone(long previous, long current, Feed feed) {
+        List<Long> milestones = List.of(5L, 10L, 25L, 50L, 100L, 250L, 500L, 1000L, 2000L, 5000L);
+
+        for (Long milestone : milestones) {
+            if (previous < milestone && current >= milestone) {
+                notificationUsecase.saveReactionCountNotification(feed, milestone);
+            }
+        }
     }
 }

--- a/src/main/java/leets/leenk/domain/notification/application/dto/response/NotificationCountResponse.java
+++ b/src/main/java/leets/leenk/domain/notification/application/dto/response/NotificationCountResponse.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.dto;
+package leets.leenk.domain.notification.application.dto.response;
 
 import lombok.Builder;
 

--- a/src/main/java/leets/leenk/domain/notification/application/dto/response/NotificationListResponse.java
+++ b/src/main/java/leets/leenk/domain/notification/application/dto/response/NotificationListResponse.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.dto;
+package leets.leenk.domain.notification.application.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/leets/leenk/domain/notification/application/dto/response/NotificationResponse.java
+++ b/src/main/java/leets/leenk/domain/notification/application/dto/response/NotificationResponse.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.dto;
+package leets.leenk.domain.notification.application.dto.response;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/leets/leenk/domain/notification/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/notification/application/exception/ErrorCode.java
@@ -10,10 +10,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode implements ErrorCodeInterface {
     NOTIFICATION_NOT_FOUND(2300, HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다."),
-    INVALID_NOTIFICATION_REQUEST_EXCEPTION(2301, HttpStatus.BAD_REQUEST,
-            "알림을 보내기 위해 필요한 정보(제목, 내용 또는 디바이스 토큰)가 누락되었습니다."),
-    INVALID_NOTIFICATION_CONTENT_TYPE_EXCEPTION(2302, HttpStatus.BAD_REQUEST, "알림 content 타입이 유효하지 않습니다."),
-    INVALID_NOTIFICATION_ACCESS(2303, HttpStatus.FORBIDDEN, "본인의 알림에만 접근할 수 있습니다.");
+    INVALID_NOTIFICATION_ACCESS(2301, HttpStatus.FORBIDDEN, "본인의 알림에만 접근할 수 있습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/notification/application/exception/InvalidNotificationContentTypeException.java
+++ b/src/main/java/leets/leenk/domain/notification/application/exception/InvalidNotificationContentTypeException.java
@@ -1,9 +1,0 @@
-package leets.leenk.domain.notification.application.exception;
-
-import leets.leenk.global.common.exception.BaseException;
-
-public class InvalidNotificationContentTypeException extends BaseException {
-    public InvalidNotificationContentTypeException() {
-        super(ErrorCode.INVALID_NOTIFICATION_CONTENT_TYPE_EXCEPTION);
-    }
-}

--- a/src/main/java/leets/leenk/domain/notification/application/exception/InvalidNotificationRequestException.java
+++ b/src/main/java/leets/leenk/domain/notification/application/exception/InvalidNotificationRequestException.java
@@ -1,9 +1,0 @@
-package leets.leenk.domain.notification.application.exception;
-
-import leets.leenk.global.common.exception.BaseException;
-
-public class InvalidNotificationRequestException extends BaseException {
-    public InvalidNotificationRequestException() {
-        super(ErrorCode.INVALID_NOTIFICATION_REQUEST_EXCEPTION);
-    }
-}

--- a/src/main/java/leets/leenk/domain/notification/application/mapper/NotificationResponseMapper.java
+++ b/src/main/java/leets/leenk/domain/notification/application/mapper/NotificationResponseMapper.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
-import leets.leenk.domain.notification.application.dto.NotificationCountResponse;
-import leets.leenk.domain.notification.application.dto.NotificationListResponse;
-import leets.leenk.domain.notification.application.dto.NotificationResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationCountResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationListResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationResponse;
 import leets.leenk.domain.notification.domain.entity.Notification;
 import leets.leenk.global.common.dto.PageableMapperUtil;
 

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -10,12 +10,12 @@ import leets.leenk.domain.notification.application.mapper.FeedFirstReactionMappe
 import leets.leenk.domain.notification.application.mapper.FeedReactionCountMapper;
 import leets.leenk.domain.notification.application.mapper.NotificationMapper;
 import leets.leenk.domain.notification.application.mapper.NotificationResponseMapper;
-import leets.leenk.domain.notification.application.service.*;
 import leets.leenk.domain.notification.domain.entity.Notification;
 import leets.leenk.domain.notification.domain.entity.content.FeedFirstReaction;
 import leets.leenk.domain.notification.domain.entity.content.FeedFirstReactionNotificationContent;
 import leets.leenk.domain.notification.domain.entity.content.FeedReactionCount;
 import leets.leenk.domain.notification.domain.entity.content.FeedReactionCountNotificationContent;
+import leets.leenk.domain.notification.domain.service.*;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.service.user.UserGetService;
 import leets.leenk.domain.user.domain.service.usersetting.UserSettingGetService;

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -5,7 +5,6 @@ import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.feed.domain.entity.Reaction;
 import leets.leenk.domain.notification.application.dto.response.NotificationCountResponse;
 import leets.leenk.domain.notification.application.dto.response.NotificationListResponse;
-import leets.leenk.domain.notification.application.exception.InvalidNotificationContentTypeException;
 import leets.leenk.domain.notification.application.mapper.FeedFirstReactionMapper;
 import leets.leenk.domain.notification.application.mapper.FeedReactionCountMapper;
 import leets.leenk.domain.notification.application.mapper.NotificationMapper;
@@ -77,7 +76,7 @@ public class NotificationUsecase {
         FeedFirstReaction feedFirstReaction = feedFirstReactionMapper.toFeedFirstReaction(reaction.getUser());
 
         if (!(notification.getContent() instanceof FeedFirstReactionNotificationContent content)) {
-            throw new InvalidNotificationContentTypeException();
+            return;
         }
 
         content.getFeedFirstReactions().add(feedFirstReaction);
@@ -109,7 +108,7 @@ public class NotificationUsecase {
         FeedReactionCount feedReactionCount = feedReactionCountMapper.toFeedReactionCount(reactionCount);
 
         if (!(notification.getContent() instanceof FeedReactionCountNotificationContent content)) {
-            throw new InvalidNotificationContentTypeException();
+            return;
         }
 
         content.getFeedReactionCounts().add(feedReactionCount);

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -127,10 +127,10 @@ public class NotificationUsecase {
     public void saveTagNotification(Feed feed, List<LinkedUser> linkedUsers) {
         linkedUsers.forEach(linkedUser -> {
             Notification notification = notificationMapper.toFeedTagNotification(feed, linkedUser);
-            String deviceToken = linkedUser.getUser().getFcmToken();
+            String fcmToken = linkedUser.getUser().getFcmToken();
             notificationSaveService.save(notification);
 
-            eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, deviceToken));
+            eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, fcmToken));
         });
     }
 

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -3,8 +3,8 @@ package leets.leenk.domain.notification.application.usecase;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.feed.domain.entity.Reaction;
-import leets.leenk.domain.notification.application.dto.NotificationCountResponse;
-import leets.leenk.domain.notification.application.dto.NotificationListResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationCountResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationListResponse;
 import leets.leenk.domain.notification.application.exception.InvalidNotificationContentTypeException;
 import leets.leenk.domain.notification.application.mapper.FeedFirstReactionMapper;
 import leets.leenk.domain.notification.application.mapper.FeedReactionCountMapper;
@@ -30,7 +30,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -91,17 +91,12 @@ public class NotificationUsecase {
 
     @Transactional
     public void saveNewFeedNotification(Feed feed) {
-        List<User> users = userSettingGetService.getUsersToNotifyNewFeed();
-        users.stream()
-                .filter(user -> !Objects.equals(user.getId(), feed.getUser().getId()))
-                .forEach(
-                        user -> {
-                            Notification notification = notificationMapper.toNewFeedNotification(feed, user);
-                            notificationSaveService.save(notification);
-                            eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, user.getFcmToken()));
-                        }
-                );
-
+        List<User> users = userSettingGetService.getUsersToNotifyNewFeed(feed.getUser().getId());
+        users.forEach(user -> {
+            Notification notification = notificationMapper.toNewFeedNotification(feed, user);
+            notificationSaveService.save(notification);
+            eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, user.getFcmToken()));
+        });
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -89,6 +89,7 @@ public class NotificationUsecase {
         }
 
         content.getFeedFirstReactions().add(feedFirstReaction);
+        notification.markUnread();
 
         notificationSaveService.save(notification);
 

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -52,8 +52,6 @@ public class NotificationUsecase {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    private static final String FCM_TOKEN_MISSING = "[알림 생략] FCM 토큰이 없어 푸시 알림을 전송하지 않음. userId = {}";
-
     @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(Long userId, int pageNumber, int pageSize) {
         Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, "updateDate"));
@@ -78,10 +76,6 @@ public class NotificationUsecase {
         Notification notification = notificationGetService.findOrCreateFirstReactionNotification(reaction);
 
         User user = userGetService.findById(notification.getUserId());
-        if(user.getFcmToken() == null){
-            log.info(FCM_TOKEN_MISSING, user.getId());
-            return;
-        }
 
         FeedFirstReaction feedFirstReaction = feedFirstReactionMapper.toFeedFirstReaction(reaction.getUser());
         if (!(notification.getContent() instanceof FeedFirstReactionNotificationContent content)) {
@@ -93,7 +87,7 @@ public class NotificationUsecase {
 
         notificationSaveService.save(notification);
 
-        if (userSettingGetService.findByUser(user).isNewReactionNotify())
+        if (userSettingGetService.findByUser(user).isNewReactionNotify() && user.getFcmToken() != null)
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedFirstReaction(feedFirstReaction, user.getFcmToken()));
     }
 
@@ -101,13 +95,11 @@ public class NotificationUsecase {
     public void saveNewFeedNotification(Feed feed) {
         List<User> users = userSettingGetService.getUsersToNotifyNewFeed(feed.getUser().getId());
         users.forEach(user -> {
-            if(user.getFcmToken()==null){
-                log.info(FCM_TOKEN_MISSING, user.getId());
-                return;
-            }
             Notification notification = notificationMapper.toNewFeedNotification(feed, user);
             notificationSaveService.save(notification);
-            eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, user.getFcmToken()));
+            if(user.getFcmToken() != null) {
+                eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, user.getFcmToken()));
+            }
         });
     }
 
@@ -120,10 +112,6 @@ public class NotificationUsecase {
         Notification notification = notificationGetService.findOrCreateReactionCountNotification(feed);
 
         User user = userGetService.findById(notification.getUserId());
-        if(user.getFcmToken() == null){
-            log.info(FCM_TOKEN_MISSING, user.getId());
-            return;
-        }
 
         FeedReactionCount feedReactionCount = feedReactionCountMapper.toFeedReactionCount(reactionCount);
         if (!(notification.getContent() instanceof FeedReactionCountNotificationContent content)) {
@@ -135,7 +123,7 @@ public class NotificationUsecase {
 
         notificationSaveService.save(notification);
 
-        if (userSettingGetService.findByUser(user).isNewReactionNotify())
+        if (userSettingGetService.findByUser(user).isNewReactionNotify() && user.getFcmToken() != null)
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedReactionCount(feedReactionCount, user.getFcmToken()));
 
     }
@@ -145,13 +133,11 @@ public class NotificationUsecase {
         linkedUsers.forEach(linkedUser -> {
             Notification notification = notificationMapper.toFeedTagNotification(feed, linkedUser);
             String fcmToken = linkedUser.getUser().getFcmToken();
-            if(fcmToken==null){
-                log.info(FCM_TOKEN_MISSING, linkedUser.getId());
-                return;
-            }
             notificationSaveService.save(notification);
 
-            eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, fcmToken));
+            if(fcmToken != null) {
+                eventPublisher.publishEvent(sqsMessageEventMapper.toSqsMessageEvent(notification, fcmToken));
+            }
         });
     }
 

--- a/src/main/java/leets/leenk/domain/notification/domain/service/NotificationCountGetService.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/service/NotificationCountGetService.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.service;
+package leets.leenk.domain.notification.domain.service;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/leets/leenk/domain/notification/domain/service/NotificationDuplicateCheckService.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/service/NotificationDuplicateCheckService.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.service;
+package leets.leenk.domain.notification.domain.service;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/leets/leenk/domain/notification/domain/service/NotificationGetService.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/service/NotificationGetService.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.service;
+package leets.leenk.domain.notification.domain.service;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;

--- a/src/main/java/leets/leenk/domain/notification/domain/service/NotificationMarkReadService.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/service/NotificationMarkReadService.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.service;
+package leets.leenk.domain.notification.domain.service;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/leets/leenk/domain/notification/domain/service/NotificationSaveService.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/service/NotificationSaveService.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.notification.application.service;
+package leets.leenk.domain.notification.domain.service;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/leets/leenk/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/leets/leenk/domain/notification/presentation/NotificationController.java
@@ -1,16 +1,11 @@
 package leets.leenk.domain.notification.presentation;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import leets.leenk.domain.notification.application.dto.NotificationCountResponse;
-import leets.leenk.domain.notification.application.dto.NotificationListResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationCountResponse;
+import leets.leenk.domain.notification.application.dto.response.NotificationListResponse;
 import leets.leenk.domain.notification.application.usecase.NotificationUsecase;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;

--- a/src/main/java/leets/leenk/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/leets/leenk/domain/notification/presentation/NotificationController.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.notification.presentation;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +24,7 @@ public class NotificationController {
 
     @Operation(summary = "최근 알림 조회 API [무한스크롤] / 사용자의 최근 알림 목록을 페이지 단위로 조회합니다. pageNumber: 0부터 시작")
     @GetMapping()
-    public CommonResponse<NotificationListResponse> getNotifications(@CurrentUserId Long userId,
+    public CommonResponse<NotificationListResponse> getNotifications(@Parameter(hidden = true) @CurrentUserId Long userId,
                                                                      @RequestParam("page") int pageNumber,
                                                                      @RequestParam("size") int pageSize) {
         return CommonResponse.success(NotificationResponseCode.NOTIFICATION_READ_SUCCESS,
@@ -32,14 +33,14 @@ public class NotificationController {
 
     @Operation(summary = "알림 개수 조회 API")
     @GetMapping("/count")
-    public CommonResponse<NotificationCountResponse> getNotificationCount(@CurrentUserId Long userId) {
+    public CommonResponse<NotificationCountResponse> getNotificationCount(@Parameter(hidden = true) @CurrentUserId Long userId) {
         return CommonResponse.success(NotificationResponseCode.NOTIFICATION_COUNT_READ_SUCCESS,
                 notificationUsecase.getNotificationCount(userId));
     }
 
     @Operation(summary = "단일 알림 읽음 처리 API")
     @PatchMapping("/{notificationId}")
-    public CommonResponse<Void> markAsRead(@CurrentUserId Long userId,
+    public CommonResponse<Void> markAsRead(@Parameter(hidden = true) @CurrentUserId Long userId,
                                            @PathVariable String notificationId) {
         notificationUsecase.markNotificationAsRead(userId, notificationId);
         return CommonResponse.success(NotificationResponseCode.NOTIFICATION_MARK_AS_READ_SUCCESS);

--- a/src/main/java/leets/leenk/domain/user/application/dto/request/FcmTokenRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/FcmTokenRequest.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenRequest(
+        @NotBlank
+        String fcmToken
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -72,6 +72,13 @@ public class UserUsecase {
     }
 
     @Transactional
+    public void updateFcmToken(long userId, FcmTokenRequest request){
+        User user = userGetService.findById(userId);
+
+        userUpdateService.updateFCMToken(user, request.fcmToken());
+    }
+
+    @Transactional
     public void leave(long userId) {
         User user = userGetService.findById(userId);
 

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -1,11 +1,6 @@
 package leets.leenk.domain.user.application.usecase;
 
-import leets.leenk.domain.user.application.dto.request.AgreementRequest;
-import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
-import leets.leenk.domain.user.application.dto.request.KakaoTalkIdRequest;
-import leets.leenk.domain.user.application.dto.request.MbtiRequest;
-import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
-import leets.leenk.domain.user.application.dto.request.RegisterRequest;
+import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.exception.SelfBlockNotAllowedException;
 import leets.leenk.domain.user.application.exception.UserAlreadyBlockedException;
@@ -95,7 +90,7 @@ public class UserUsecase {
     public void updateFcmToken(long userId, FcmTokenRequest request){
         User user = userGetService.findById(userId);
 
-        userUpdateService.updateFCMToken(user, request.fcmToken());
+        userUpdateService.updateFcmToken(user, request.fcmToken());
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -73,6 +73,10 @@ public class User extends BaseEntity {
         this.mbti = mbti;
     }
 
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+
     public void increaseTotalReactionCount(long reactionCount) {
         this.totalReactionCount += reactionCount;
     }

--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserSettingRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserSettingRepository.java
@@ -8,12 +8,12 @@ import leets.leenk.domain.user.domain.entity.UserSetting;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
-
 public interface UserSettingRepository extends JpaRepository<UserSetting, Long> {
 
-	@Query("SELECT us FROM UserSetting us JOIN FETCH us.user WHERE us.isNewFeedNotify = true")
-	List<UserSetting> findAllByIsNewFeedNotifyTrue();
+	@Query("SELECT us.user FROM UserSetting us WHERE us.isNewFeedNotify = true " +
+			"AND us.user.leaveDate IS NULL " +
+			"AND us.user.id <> :userId")
+	List<User> findAllActiveUsersWithNewFeedNotifyTrueExcludingUserId(Long userId);
 
     Optional<UserSetting> findByUser(User user);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
@@ -38,4 +38,8 @@ public class UserUpdateService {
     public void updateMbti(User user, String mbti) {
         user.updateMbti(mbti);
     }
+
+    public void updateFCMToken(User user, String fcmToken){
+        user.updateFcmToken(fcmToken);
+    }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
@@ -44,7 +44,7 @@ public class UserUpdateService {
         user.updateMbti(mbti);
     }
 
-    public void updateFCMToken(User user, String fcmToken){
+    public void updateFcmToken(User user, String fcmToken){
         user.updateFcmToken(fcmToken);
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/usersetting/UserSettingGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/usersetting/UserSettingGetService.java
@@ -15,11 +15,8 @@ import lombok.RequiredArgsConstructor;
 public class UserSettingGetService {
 	private final UserSettingRepository userSettingRepository;
 
-	public List<User> getUsersToNotifyNewFeed() {
-		return userSettingRepository.findAllByIsNewFeedNotifyTrue()
-			.stream()
-			.map(UserSetting::getUser)
-			.toList();
+	public List<User> getUsersToNotifyNewFeed(Long userId) {
+		return userSettingRepository.findAllActiveUsersWithNewFeedNotifyTrueExcludingUserId(userId);
 	}
 
     public UserSetting findByUser(User user) {

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -20,7 +20,8 @@ public enum ResponseCode implements ResponseCodeInterface {
 
     GET_NOTIFICATION_SETTING(1110, HttpStatus.OK, "알림 설정 조회에 성공했습니다."),
     UPDATE_NOTIFICATION_SETTING(1111, HttpStatus.OK, "알림 설정 수정에 성공했습니다."),
-    SEND_FEEDBACK(1112, HttpStatus.OK, "의견 남기기에 성공했습니다.");
+    SEND_FEEDBACK(1112, HttpStatus.OK, "의견 남기기에 성공했습니다."),
+    UPDATE_FCM_TOKEN(1113, HttpStatus.OK, "fcm 토큰 수정에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -83,6 +83,15 @@ public class UserController {
         return CommonResponse.success(UPDATE_MBTI);
     }
 
+    @PatchMapping("/me/fcm-token")
+    @Operation(summary = "내 정보 수정 - FCM 토큰")
+    public CommonResponse<Void> updateFcmToken(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                           @Valid @RequestBody FcmTokenRequest request) {
+        userUsecase.updateFcmToken(userId, request);
+
+        return CommonResponse.success(UPDATE_FCM_TOKEN);
+    }
+
     @DeleteMapping("/me")
     @Operation(summary = "회원 탈퇴 API")
     public CommonResponse<Void> deleteAccount(@Parameter(hidden = true) @CurrentUserId Long userId) {

--- a/src/main/java/leets/leenk/global/sqs/application/dto/SqsMessageEvent.java
+++ b/src/main/java/leets/leenk/global/sqs/application/dto/SqsMessageEvent.java
@@ -9,18 +9,18 @@ public class SqsMessageEvent {
 
 	private final String title;
 	private final String content;
-	private final String deviceToken;
+	private final String fcmToken;
 
 	@Builder
-	private SqsMessageEvent(String title, String content, String deviceToken) {
+	private SqsMessageEvent(String title, String content, String fcmToken) {
 		this.title = title;
 		this.content = content;
-		this.deviceToken = deviceToken;
+		this.fcmToken = fcmToken;
 		validateSqsMessageEvent();
 	}
 
 	private void validateSqsMessageEvent(){
-		if(isEmptyString(content) || isEmptyString(title) || isEmptyString(deviceToken)){
+		if(isEmptyString(content) || isEmptyString(title) || isEmptyString(fcmToken)){
 			throw new InvalidNotificationRequestException();
 		}
 	}

--- a/src/main/java/leets/leenk/global/sqs/application/dto/SqsMessageEvent.java
+++ b/src/main/java/leets/leenk/global/sqs/application/dto/SqsMessageEvent.java
@@ -1,32 +1,14 @@
 package leets.leenk.global.sqs.application.dto;
 
-import leets.leenk.domain.notification.application.exception.InvalidNotificationRequestException;
 import lombok.Builder;
 import lombok.Getter;
 
+@Builder
 @Getter
 public class SqsMessageEvent {
 
 	private final String title;
 	private final String content;
 	private final String fcmToken;
-
-	@Builder
-	private SqsMessageEvent(String title, String content, String fcmToken) {
-		this.title = title;
-		this.content = content;
-		this.fcmToken = fcmToken;
-		validateSqsMessageEvent();
-	}
-
-	private void validateSqsMessageEvent(){
-		if(isEmptyString(content) || isEmptyString(title) || isEmptyString(fcmToken)){
-			throw new InvalidNotificationRequestException();
-		}
-	}
-
-	private boolean isEmptyString(String string) {
-		return string == null || string.isEmpty();
-	}
 
 }

--- a/src/main/java/leets/leenk/global/sqs/application/mapper/AwsSqsManager.java
+++ b/src/main/java/leets/leenk/global/sqs/application/mapper/AwsSqsManager.java
@@ -29,7 +29,7 @@ public class AwsSqsManager {
 			.messageBody(event.getContent())
 			.messageAttributes(Map.of(
 				"title", convertToAttributeValue(event.getTitle()),
-				"deviceToken", convertToAttributeValue(event.getDeviceToken())
+				"fcmToken", convertToAttributeValue(event.getFcmToken())
 			))
 			.build();
 	}

--- a/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
+++ b/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
@@ -10,28 +10,28 @@ import leets.leenk.domain.notification.domain.entity.Notification;
 @Component
 public class SqsMessageEventMapper {
 
-	public SqsMessageEvent toSqsMessageEvent(Notification notification, String deviceToken) {
+	public SqsMessageEvent toSqsMessageEvent(Notification notification, String fcmToken) {
 
 		return SqsMessageEvent.builder()
 			.title(notification.getContent().getTitle())
 			.content(notification.getContent().getBody())
-			.deviceToken(deviceToken)
+			.fcmToken(fcmToken)
 			.build();
 	}
 
-	public SqsMessageEvent fromFeedFirstReaction(FeedFirstReaction feedFirstReaction, String deviceToken) {
+	public SqsMessageEvent fromFeedFirstReaction(FeedFirstReaction feedFirstReaction, String fcmToken) {
 		return SqsMessageEvent.builder()
 			.title(feedFirstReaction.getTitle())
 			.content(feedFirstReaction.getBody())
-			.deviceToken(deviceToken)
+			.fcmToken(fcmToken)
 			.build();
 	}
 
-	public SqsMessageEvent fromFeedReactionCount(FeedReactionCount feedReactionCount, String deviceToken) {
+	public SqsMessageEvent fromFeedReactionCount(FeedReactionCount feedReactionCount, String fcmToken) {
 		return SqsMessageEvent.builder()
 			.title(feedReactionCount.getTitle())
 			.content(feedReactionCount.getBody())
-			.deviceToken(deviceToken)
+			.fcmToken(fcmToken)
 			.build();
 	}
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #30 

## 작업 내용 💻

- 새로운 피드 알림에서 탈퇴하지 않은 유저 중에서 알림을 허용한 전체 사용자에게 알림 보내도록 수정
- 피드 생성 시 새 피드 알림 저장
- 피드 생성 시 태그 알림 저장
- 새로운 공감 알림 저장
- 누적 공감 알림 저장

## 스크린샷 📷

- 피드 생성 시 새 피드 알림을 활성한 유저와 태그된 유저에게 각각 새 피드 및 태그 알림을 저장한 DB
- ![image](https://github.com/user-attachments/assets/b461063a-5fef-4346-b830-61f7363d706e)
- 누적 공감 알림 시 DB에 저장된 content 내용
```json
{
  "feedId": {
    "$numberLong": "1"
  },
  "feedReactionCounts": [
    {
      "reactionCount": {
        "$numberLong": "5"
      },
      "title": "누적 공감",
      "body": "내가 쓴 피드에 공감 5개 받았어"
    },
    {
      "reactionCount": {
        "$numberLong": "10"
      },
      "title": "누적 공감",
      "body": "내가 쓴 피드에 공감 10개 받았어"
    },
    {
      "reactionCount": {
        "$numberLong": "25"
      },
      "title": "누적 공감",
      "body": "내가 쓴 피드에 공감 25개 받았어"
    }
  ],
  "_class": "leets.leenk.domain.notification.domain.entity.content.FeedReactionCountNotificationContent"
}


```

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢
회의에서 나눴던 내용
- 회의에서 나눴던 내용인 알림 로고 이미지는 프론트에서 작업해야하는 사항으로 알고있어서 수정하지 않았습니다
- ```SqsEventHandler``` 클래스의 ```handleEvent()```메서드 내에서 try-catch로 알림을 보내고 예상치 못한 사유로 실패할 경우 로그가 남습니다(전 PR에 작성)
- 만약 떠났거나 탈퇴한 유저라면 fcmToken의 값이 null이 되는데, ```SqsMessageEvent``` 생성시 ```title, content, fcmToken``` 중 값이 없거나 null인 경우 return;이 되어 알림은 생성되지 않습니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **버그 수정**
  * 피드 알림 발송 시 피드 작성자가 알림 대상에서 제외되어 중복 알림이 발생하지 않도록 개선되었습니다.
  * 알림 발송 대상이 탈퇴하지 않은 활성 사용자로 한정됩니다.
  * 알림 생성 시 FCM 토큰이 없는 경우 알림 발송을 건너뛰도록 하여 불필요한 예외 발생을 방지합니다.

* **신규 기능**
  * 사용자 FCM 토큰을 업데이트할 수 있는 기능이 추가되었습니다.
  * 사용자 본인의 FCM 토큰을 수정하는 API가 새로 도입되었습니다.
  * 피드 업로드 및 리액션 시 관련 알림이 자동으로 발송되도록 확장되었습니다.
  * 피드 리액션 수가 특정 마일스톤(5, 10, 25, 50, 100 등)에 도달할 때 알림이 발송됩니다.

* **스타일**
  * 일부 변수명(deviceToken → fcmToken)이 보다 명확하게 변경되어 일관성이 향상되었습니다.

* **문서화**
  * 알림 관련 패키지 구조가 정리되고, 메서드 및 파라미터 명칭이 실제 사용 목적에 맞게 정정되었습니다.
  * API 문서에서 사용자 ID 파라미터가 숨김 처리되어 가독성이 개선되었습니다.

* **기타**
  * 알림 요청 및 내용 타입 관련 예외 처리 로직이 간소화되어 안정성이 높아졌습니다.
  * 불필요한 예외 클래스 및 오류 코드가 제거되어 코드가 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->