### PR TITLE
LNK-BE-14 약관 동의 API 구현

### DIFF
--- a/src/main/java/leets/leenk/domain/user/application/dto/request/AgreementRequest.java
+++ b/src/main/java/leets/leenk/domain/user/application/dto/request/AgreementRequest.java
@@ -1,0 +1,10 @@
+package leets.leenk.domain.user.application.dto.request;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
+public record AgreementRequest(
+        @NotNull @AssertTrue(message = "서비스 이용 약관에 동의해주세요") boolean termsService,
+        @NotNull @AssertTrue(message = "개인정보 수집에 동의해주세요") boolean privacyPolicy
+) {
+}

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -38,7 +38,7 @@ public class UserUsecase {
     public void initialAgreement(long userId, AgreementRequest request) {
         User user = userGetService.findById(userId);
 
-        userUpdateService.initialAgreement(user, request);
+        userUpdateService.updateAgreement(user, request);
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -1,6 +1,11 @@
 package leets.leenk.domain.user.application.usecase;
 
-import leets.leenk.domain.user.application.dto.request.*;
+import leets.leenk.domain.user.application.dto.request.AgreementRequest;
+import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
+import leets.leenk.domain.user.application.dto.request.KakaoTalkIdRequest;
+import leets.leenk.domain.user.application.dto.request.MbtiRequest;
+import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
+import leets.leenk.domain.user.application.dto.request.RegisterRequest;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.exception.UserAlreadyLeaveException;
 import leets.leenk.domain.user.application.mapper.UserBackupInfoMapper;
@@ -28,6 +33,13 @@ public class UserUsecase {
     private final UserBackupInfoMapper userBackupInfoMapper;
     private final UserBackupInfoSaveService userBackupInfoSaveService;
     private final UserBackupInfoGetService userBackupInfoGetService;
+
+    @Transactional
+    public void initialAgreement(long userId, AgreementRequest request) {
+        User user = userGetService.findById(userId);
+
+        userUpdateService.initialAgreement(user, request);
+    }
 
     @Transactional
     public void completeProfile(long userId, RegisterRequest request) {

--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -5,19 +5,20 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import leets.leenk.global.auth.application.dto.response.OauthUserInfoResponse;
 import leets.leenk.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-
-import java.time.LocalDateTime;
+import org.hibernate.annotations.ColumnDefault;
 
 @Getter
 @Entity
 @SuperBuilder
-@Table(name="users")
+@Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
@@ -53,6 +54,16 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private long totalReactionCount;
 
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    @Builder.Default
+    private Boolean termsAgreement = false;
+
+    @Column(nullable = false)
+    @ColumnDefault("false")
+    @Builder.Default
+    private Boolean privacyAgreement = false;
+
     private LocalDateTime leaveDate;
 
     private LocalDateTime deleteDate;
@@ -73,14 +84,23 @@ public class User extends BaseEntity {
         this.mbti = mbti;
     }
 
+    public void updateAgreement(boolean termsService, boolean privacyPolicy) {
+        this.termsAgreement = termsService;
+        this.privacyAgreement = privacyPolicy;
+    }
+
     public void increaseTotalReactionCount(long reactionCount) {
         this.totalReactionCount += reactionCount;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof User user)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof User user)) {
+            return false;
+        }
         return id != null && id.equals(user.id);
     }
 

--- a/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
@@ -1,11 +1,16 @@
 package leets.leenk.domain.user.domain.service.user;
 
+import leets.leenk.domain.user.application.dto.request.AgreementRequest;
 import leets.leenk.domain.user.application.dto.request.RegisterRequest;
 import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.stereotype.Service;
 
 @Service
 public class UserUpdateService {
+
+    public void initialAgreement(User user, AgreementRequest request) {
+        user.updateAgreement(request.termsService(), request.privacyPolicy());
+    }
 
     public void completeProfile(User user, RegisterRequest request) {
         user.updateKakaoTalkId(request.kakaoTalkId());

--- a/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserUpdateService {
 
-    public void initialAgreement(User user, AgreementRequest request) {
+    public void updateAgreement(User user, AgreementRequest request) {
         user.updateAgreement(request.termsService(), request.privacyPolicy());
     }
 

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -17,7 +17,7 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다."),
     COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
     DELETE_USER(1107, HttpStatus.OK, "회원 탈퇴에 성공했습니다."),
-    UPDATE_AGREEMENT(1108, HttpStatus.OK, "약관 동의 입력에 성공했습니다."),
+    UPDATE_AGREEMENT(1109, HttpStatus.OK, "약관 동의 입력에 성공했습니다."),
 
     GET_NOTIFICATION_SETTING(1110, HttpStatus.OK, "알림 설정 조회에 성공했습니다."),
     UPDATE_NOTIFICATION_SETTING(1111, HttpStatus.OK, "알림 설정 수정에 성공했습니다."),

--- a/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/ResponseCode.java
@@ -17,6 +17,7 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPDATE_KAKAO_TALK_ID(1105, HttpStatus.OK, "카카오톡 Id 수정에 성공했습니다."),
     COMPLETE_PROFILE(1106, HttpStatus.OK, "기본 정보 입력에 성공했습니다."),
     DELETE_USER(1107, HttpStatus.OK, "회원 탈퇴에 성공했습니다."),
+    UPDATE_AGREEMENT(1108, HttpStatus.OK, "약관 동의 입력에 성공했습니다."),
 
     GET_NOTIFICATION_SETTING(1110, HttpStatus.OK, "알림 설정 조회에 성공했습니다."),
     UPDATE_NOTIFICATION_SETTING(1111, HttpStatus.OK, "알림 설정 수정에 성공했습니다."),

--- a/src/main/java/leets/leenk/domain/user/presentation/UserController.java
+++ b/src/main/java/leets/leenk/domain/user/presentation/UserController.java
@@ -1,18 +1,37 @@
 package leets.leenk.domain.user.presentation;
 
+import static leets.leenk.domain.user.presentation.ResponseCode.COMPLETE_PROFILE;
+import static leets.leenk.domain.user.presentation.ResponseCode.DELETE_USER;
+import static leets.leenk.domain.user.presentation.ResponseCode.GET_MY_INFO;
+import static leets.leenk.domain.user.presentation.ResponseCode.GET_USER_INFO;
+import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_AGREEMENT;
+import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_INTRODUCTION;
+import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_KAKAO_TALK_ID;
+import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_MBTI;
+import static leets.leenk.domain.user.presentation.ResponseCode.UPDATE_PROFILE_IMAGE;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import leets.leenk.domain.user.application.dto.request.*;
+import leets.leenk.domain.user.application.dto.request.AgreementRequest;
+import leets.leenk.domain.user.application.dto.request.IntroductionRequest;
+import leets.leenk.domain.user.application.dto.request.KakaoTalkIdRequest;
+import leets.leenk.domain.user.application.dto.request.MbtiRequest;
+import leets.leenk.domain.user.application.dto.request.ProfileImageRequest;
+import leets.leenk.domain.user.application.dto.request.RegisterRequest;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.usecase.UserUsecase;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
-import static leets.leenk.domain.user.presentation.ResponseCode.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "USER")
 @RestController
@@ -22,10 +41,19 @@ public class UserController {
 
     private final UserUsecase userUsecase;
 
+    @PatchMapping("/agreement")
+    @Operation(summary = "약관 동의 입력")
+    public CommonResponse<Void> initialAgreement(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                 @RequestBody @Valid AgreementRequest request) {
+        userUsecase.initialAgreement(userId, request);
+
+        return CommonResponse.success(UPDATE_AGREEMENT);
+    }
+
     @PatchMapping("/me/profile")
     @Operation(summary = "기본 정보 입력")
     public CommonResponse<Void> completeProfile(@Parameter(hidden = true) @CurrentUserId Long userId,
-                                            @RequestBody @Valid RegisterRequest request) {
+                                                @RequestBody @Valid RegisterRequest request) {
         userUsecase.completeProfile(userId, request);
 
         return CommonResponse.success(COMPLETE_PROFILE);
@@ -50,7 +78,7 @@ public class UserController {
     @PatchMapping("/me/kakao-talk-id")
     @Operation(summary = "내 정보 수정 - 카카오톡 id")
     public CommonResponse<Void> updateKakaoTalkId(@Parameter(hidden = true) @CurrentUserId Long userId,
-                                                   @Valid @RequestBody KakaoTalkIdRequest request) {
+                                                  @Valid @RequestBody KakaoTalkIdRequest request) {
         userUsecase.updateKakaoTalkId(userId, request);
 
         return CommonResponse.success(UPDATE_KAKAO_TALK_ID);


### PR DESCRIPTION
## Related issue 🛠
- closed #31 

## 작업 내용 💻

- [x] 약관동의 컨트롤러단 구현
- [x] 비즈니스 로직 구현

## 스크린샷 📷

![image](https://github.com/user-attachments/assets/961f03ca-7b8f-4bf8-9d79-d386d9d6c9b8)


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 간단한 내용이라 로직적인건 없었는데, `Boolean` 필드로 필수 동의 항목을 입력받기때문에 
유저가 `false`로 필수 항목을 동의안하는 경우, 검증을 `DTO` 단에 책임이라 생각해서 @AssertTrue로 구현했습니당
이거 관련해서 같이 얘기해보면 좋을거같아요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이용약관 및 개인정보 처리방침 동의 상태를 입력하는 API 엔드포인트가 추가되었습니다.
  * 사용자 동의 정보(이용약관, 개인정보 처리방침)를 저장 및 갱신할 수 있습니다.
  * 동의 입력 성공 시 새로운 응답 코드 및 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->