### PR TITLE
LNK-BE-17 id & 비번 로그인 구현

### DIFF
--- a/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/leets/leenk/domain/user/domain/repository/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Slice<User> findAllByLeaveDateIsNullAndDeleteDateIsNullOrderByName(Pageable pageable);
 
     List<User> findByDeleteDateIsNullAndLeaveDateBefore(LocalDateTime threshold);
+
+    Optional<User> findByName(String name);
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/user/UserGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/user/UserGetService.java
@@ -42,4 +42,9 @@ public class UserGetService {
     public List<User> findAllDeleteUser(LocalDateTime threshold) {
         return userRepository.findByDeleteDateIsNullAndLeaveDateBefore(threshold);
     }
+
+    public User findByEmail(String email) {
+        return userRepository.findByName("마스터")
+                .orElseThrow(UserNotFoundException::new);
+    }
 }

--- a/src/main/java/leets/leenk/global/auth/application/dto/request/UsernamePasswordLoginRequest.java
+++ b/src/main/java/leets/leenk/global/auth/application/dto/request/UsernamePasswordLoginRequest.java
@@ -1,0 +1,12 @@
+package leets.leenk.global.auth.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UsernamePasswordLoginRequest(
+        @NotBlank
+        String email,
+
+        @NotBlank
+        String password
+) {
+}

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -1,5 +1,6 @@
 package leets.leenk.global.auth.application.usecase;
 
+import leets.leenk.domain.user.application.exception.UserNotFoundException;
 import leets.leenk.domain.user.application.mapper.UserMapper;
 import leets.leenk.domain.user.application.mapper.UserSettingMapper;
 import leets.leenk.domain.user.domain.entity.User;
@@ -11,6 +12,7 @@ import leets.leenk.domain.user.domain.service.userbackup.UserBackupInfoDeleteSer
 import leets.leenk.domain.user.domain.service.userbackup.UserBackupInfoGetService;
 import leets.leenk.domain.user.domain.service.usersetting.UserSettingSaveService;
 import leets.leenk.global.auth.application.dto.request.RefreshTokenRequest;
+import leets.leenk.global.auth.application.dto.request.UsernamePasswordLoginRequest;
 import leets.leenk.global.auth.application.dto.response.LoginResponse;
 import leets.leenk.global.auth.application.dto.response.OauthTokenResponse;
 import leets.leenk.global.auth.application.dto.response.OauthUserInfoResponse;
@@ -18,6 +20,7 @@ import leets.leenk.global.auth.application.mapper.LoginMapper;
 import leets.leenk.global.auth.domain.service.KakaoOauthApiService;
 import leets.leenk.global.auth.domain.service.OauthApiService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.stereotype.Service;
@@ -43,6 +46,15 @@ public class AuthUsecase {
     private final UserSettingMapper userSettingMapper;
 
     private final JwtDecoder jwtDecoder;
+
+    @Value("${token.access_token}")
+    private String accessToken;
+
+    @Value("${token.refresh_token}")
+    private String refreshToken;
+
+    @Value("${token.password}")
+    private String password;
 
     @Transactional
     public LoginResponse kakaoLogin(String kakaoAccessToken) {
@@ -104,5 +116,15 @@ public class AuthUsecase {
         OauthTokenResponse response = kakaoOauthApiService.reissueOauthToken(request.refreshToken());
 
         return loginMapper.toLoginResponse(response.access_token(), response.refresh_token());
+    }
+
+    public LoginResponse login(UsernamePasswordLoginRequest request) {
+        User user = userGetService.findByEmail(request.email());
+        if (!request.password().equals(password)) {
+            throw new UserNotFoundException();
+        }
+
+        return loginMapper.toLoginResponse(accessToken, refreshToken);
+
     }
 }

--- a/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
+++ b/src/main/java/leets/leenk/global/auth/presentation/controller/AuthController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.leenk.global.auth.application.dto.request.RefreshTokenRequest;
+import leets.leenk.global.auth.application.dto.request.UsernamePasswordLoginRequest;
 import leets.leenk.global.auth.application.dto.response.LoginResponse;
 import leets.leenk.global.auth.application.usecase.AuthUsecase;
 import leets.leenk.global.common.response.CommonResponse;
@@ -37,5 +38,13 @@ public class AuthController {
         LoginResponse response = authUsecase.reissueToken(request);
 
         return CommonResponse.success(ResponseCode.REFRESH_TOKEN_SUCCESS, response);
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "로그인 API")
+    public CommonResponse<LoginResponse> login(@Valid @RequestBody UsernamePasswordLoginRequest request) {
+        LoginResponse response = authUsecase.login(request);
+
+        return CommonResponse.success(ResponseCode.LOGIN_SUCCESS, response);
     }
 }

--- a/src/main/java/leets/leenk/global/config/PermitUrlConfig.java
+++ b/src/main/java/leets/leenk/global/config/PermitUrlConfig.java
@@ -10,6 +10,7 @@ public class PermitUrlConfig {
                 "/swagger-ui/**",
                 "/health-check",
                 "/kakao/login",
+                "/login",
                 "/refresh"
         };
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,8 @@ notion:
 
 slack:
   webhook_url: ${SLACK_WEBHOOK_URL}
+
+token:
+  access_token: ${ACCESS_TOKEN}
+  refresh_token: ${REFRESH_TOKEN}
+  password: ${PASSWORD}


### PR DESCRIPTION
## Related issue 🛠
- closed #38 

## 작업 내용 💻

- 심사용 id & 비번 로그인 API를 구현했습니다
- 거의 하드코딩으로 구현하긴 했는데, 임시 API 구현을 위해서 인증 서버와 연동하는 과정은 너무 리소스가 큰것 같았습니다

## 스크린샷 📷

- 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 통과 되겟죠..?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 이름 기반 조회 기능이 추가되었습니다.
  * 이메일과 비밀번호를 이용한 로그인 API가 추가되었습니다.
  * 로그인 요청을 위한 데이터 전송 객체(DTO)가 도입되었습니다.
  * 로그인 엔드포인트(/login)가 공개 URL 목록에 포함되었습니다.
  * 로그인 성공 시 액세스 및 리프레시 토큰이 반환됩니다.

* **설정**
  * 토큰 및 비밀번호 관련 환경 변수 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->