### PR TITLE
LNK-BE-18 공감 알림 버그 수정

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -239,7 +239,8 @@ public class FeedUsecase {
     }
 
     private void notifyIfReachedReactionMilestone(long previous, long current, Feed feed) {
-        List<Long> milestones = List.of(5L, 10L, 25L, 50L, 100L, 250L, 500L, 1000L, 2000L, 5000L);
+        List<Long> milestones = List.of(5L, 10L, 25L, 50L, 100L, 250L, 500L, 1000L,
+                2000L, 5000L, 10000L, 20000L, 50000L, 100000L);
 
         for (Long milestone : milestones) {
             if (previous < milestone && current >= milestone) {

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -137,7 +137,6 @@ public class FeedUsecase {
         long previousReactionCount = reaction.getReactionCount();
 
         feedUpdateService.updateTotalReaction(feed, reaction, feed.getUser(), request.reactionCount());
-
         notificationUsecase.saveFirstReactionNotification(reaction);
 
         long updatedReactionCount = previousReactionCount + request.reactionCount();
@@ -239,10 +238,9 @@ public class FeedUsecase {
     }
 
     private void notifyIfReachedReactionMilestone(long previous, long current, Feed feed) {
-        List<Long> milestones = List.of(5L, 10L, 25L, 50L, 100L, 250L, 500L, 1000L,
-                2000L, 5000L, 10000L, 20000L, 50000L, 100000L);
+        long[] milestones = {5, 10, 25, 50, 100, 250, 500, 1000, 2000, 5000, 10000, 20000, 50000, 100000};
 
-        for (Long milestone : milestones) {
+        for (long milestone : milestones) {
             if (previous < milestone && current >= milestone) {
                 notificationUsecase.saveReactionCountNotification(feed, milestone);
             }

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -107,7 +107,7 @@ public class NotificationUsecase {
     }
 
     @Transactional
-    public void saveReactionCountNotification(Feed feed, Long reactionCount) {
+    public void saveReactionCountNotification(Feed feed, long reactionCount) {
         if (notificationDuplicateCheckService.checkReactionCountDuplicated(reactionCount, feed)) {
             return;    // 이미 해당 누적 공감에 대한 알림이 있는 경우 중복 생성 방지
         }
@@ -128,9 +128,9 @@ public class NotificationUsecase {
 
         UserSetting userSetting = userSettingGetService.findByUser(user).orElse(null);
 
-        if (userSetting != null && userSetting.isNewReactionNotify() && user.getFcmToken() != null)
+        if (userSetting != null && userSetting.isNewReactionNotify() && user.getFcmToken() != null) {
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedReactionCount(feedReactionCount, user.getFcmToken()));
-
+        }
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -16,6 +16,7 @@ import leets.leenk.domain.notification.domain.entity.content.FeedReactionCount;
 import leets.leenk.domain.notification.domain.entity.content.FeedReactionCountNotificationContent;
 import leets.leenk.domain.notification.domain.service.*;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.entity.UserSetting;
 import leets.leenk.domain.user.domain.service.user.UserGetService;
 import leets.leenk.domain.user.domain.service.usersetting.UserSettingGetService;
 import leets.leenk.global.sqs.application.mapper.SqsMessageEventMapper;
@@ -87,7 +88,9 @@ public class NotificationUsecase {
 
         notificationSaveService.save(notification);
 
-        if (userSettingGetService.findByUser(user).isNewReactionNotify() && user.getFcmToken() != null)
+        UserSetting userSetting = userSettingGetService.findByUser(user).orElse(null);
+
+        if (userSetting != null && userSetting.isNewReactionNotify() && user.getFcmToken() != null)
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedFirstReaction(feedFirstReaction, user.getFcmToken()));
     }
 
@@ -123,7 +126,9 @@ public class NotificationUsecase {
 
         notificationSaveService.save(notification);
 
-        if (userSettingGetService.findByUser(user).isNewReactionNotify() && user.getFcmToken() != null)
+        UserSetting userSetting = userSettingGetService.findByUser(user).orElse(null);
+
+        if (userSetting != null && userSetting.isNewReactionNotify() && user.getFcmToken() != null)
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedReactionCount(feedReactionCount, user.getFcmToken()));
 
     }

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/NotificationUsecase.java
@@ -88,7 +88,12 @@ public class NotificationUsecase {
 
         notificationSaveService.save(notification);
 
-        UserSetting userSetting = userSettingGetService.findByUser(user).orElse(null);
+        UserSetting userSetting;
+        try{
+            userSetting = userSettingGetService.findByUser(user);
+        } catch (Exception e){
+            return;
+        }
 
         if (userSetting != null && userSetting.isNewReactionNotify() && user.getFcmToken() != null)
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedFirstReaction(feedFirstReaction, user.getFcmToken()));
@@ -126,7 +131,12 @@ public class NotificationUsecase {
 
         notificationSaveService.save(notification);
 
-        UserSetting userSetting = userSettingGetService.findByUser(user).orElse(null);
+        UserSetting userSetting;
+        try{
+            userSetting = userSettingGetService.findByUser(user);
+        } catch (Exception e){
+            return;
+        }
 
         if (userSetting != null && userSetting.isNewReactionNotify() && user.getFcmToken() != null) {
             eventPublisher.publishEvent(sqsMessageEventMapper.fromFeedReactionCount(feedReactionCount, user.getFcmToken()));

--- a/src/main/java/leets/leenk/domain/notification/domain/service/NotificationDuplicateCheckService.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/service/NotificationDuplicateCheckService.java
@@ -18,7 +18,7 @@ public class NotificationDuplicateCheckService {
                 NotificationType.FEED_FIRST_REACTION, reaction.getFeed().getId(), reaction.getUser().getId()).isPresent();
     }
 
-    public boolean checkReactionCountDuplicated(Long reactionCount, Feed feed) {
+    public boolean checkReactionCountDuplicated(long reactionCount, Feed feed) {
         return notificationRepository.findByFeedIdAndReactionCount(NotificationType.FEED_REACTION_COUNT, feed.getId(), reactionCount).isPresent();
     }
 }

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
@@ -2,7 +2,6 @@ package leets.leenk.domain.user.application.usecase;
 
 import leets.leenk.domain.user.application.dto.request.NotificationSettingUpdateRequest;
 import leets.leenk.domain.user.application.dto.response.NotificationSettingResponse;
-import leets.leenk.domain.user.application.exception.UserSettingNotFoundException;
 import leets.leenk.domain.user.application.mapper.UserSettingMapper;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserSetting;
@@ -30,7 +29,7 @@ public class UserSettingUsecase {
     @Transactional(readOnly = true)
     public NotificationSettingResponse getNotificationSetting(long userId) {
         User user = userGetService.findById(userId);
-        UserSetting userSetting = userSettingGetService.findByUser(user).orElseThrow(UserSettingNotFoundException::new);
+        UserSetting userSetting = userSettingGetService.findByUser(user);
 
         return userSettingMapper.toNotificationSettingResponse(userSetting);
     }
@@ -38,7 +37,7 @@ public class UserSettingUsecase {
     @Transactional
     public void updateNotifications(long userId, NotificationSettingUpdateRequest request) {
         User user = userGetService.findById(userId);
-        UserSetting userSetting = userSettingGetService.findByUser(user).orElseThrow(UserSettingNotFoundException::new);
+        UserSetting userSetting = userSettingGetService.findByUser(user);
 
         userSettingUpdateService.updateNotificationSetting(userSetting, request);
     }

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserSettingUsecase.java
@@ -2,6 +2,7 @@ package leets.leenk.domain.user.application.usecase;
 
 import leets.leenk.domain.user.application.dto.request.NotificationSettingUpdateRequest;
 import leets.leenk.domain.user.application.dto.response.NotificationSettingResponse;
+import leets.leenk.domain.user.application.exception.UserSettingNotFoundException;
 import leets.leenk.domain.user.application.mapper.UserSettingMapper;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserSetting;
@@ -29,7 +30,7 @@ public class UserSettingUsecase {
     @Transactional(readOnly = true)
     public NotificationSettingResponse getNotificationSetting(long userId) {
         User user = userGetService.findById(userId);
-        UserSetting userSetting = userSettingGetService.findByUser(user);
+        UserSetting userSetting = userSettingGetService.findByUser(user).orElseThrow(UserSettingNotFoundException::new);
 
         return userSettingMapper.toNotificationSettingResponse(userSetting);
     }
@@ -37,7 +38,7 @@ public class UserSettingUsecase {
     @Transactional
     public void updateNotifications(long userId, NotificationSettingUpdateRequest request) {
         User user = userGetService.findById(userId);
-        UserSetting userSetting = userSettingGetService.findByUser(user);
+        UserSetting userSetting = userSettingGetService.findByUser(user).orElseThrow(UserSettingNotFoundException::new);
 
         userSettingUpdateService.updateNotificationSetting(userSetting, request);
     }

--- a/src/main/java/leets/leenk/domain/user/domain/service/usersetting/UserSettingGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/usersetting/UserSettingGetService.java
@@ -1,10 +1,10 @@
 package leets.leenk.domain.user.domain.service.usersetting;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import leets.leenk.domain.user.application.exception.UserSettingNotFoundException;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserSetting;
 import leets.leenk.domain.user.domain.repository.UserSettingRepository;
@@ -19,8 +19,7 @@ public class UserSettingGetService {
 		return userSettingRepository.findAllActiveUsersWithNewFeedNotifyTrueExcludingUserId(userId);
 	}
 
-    public UserSetting findByUser(User user) {
-        return userSettingRepository.findByUser(user)
-                .orElseThrow(UserSettingNotFoundException::new);
+    public Optional<UserSetting> findByUser(User user) {
+        return userSettingRepository.findByUser(user);
     }
 }

--- a/src/main/java/leets/leenk/domain/user/domain/service/usersetting/UserSettingGetService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/usersetting/UserSettingGetService.java
@@ -1,8 +1,8 @@
 package leets.leenk.domain.user.domain.service.usersetting;
 
 import java.util.List;
-import java.util.Optional;
 
+import leets.leenk.domain.user.application.exception.UserSettingNotFoundException;
 import org.springframework.stereotype.Service;
 
 import leets.leenk.domain.user.domain.entity.User;
@@ -19,7 +19,7 @@ public class UserSettingGetService {
 		return userSettingRepository.findAllActiveUsersWithNewFeedNotifyTrueExcludingUserId(userId);
 	}
 
-    public Optional<UserSetting> findByUser(User user) {
-        return userSettingRepository.findByUser(user);
+    public UserSetting findByUser(User user) {
+        return userSettingRepository.findByUser(user).orElseThrow(UserSettingNotFoundException::new);
     }
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #40 

## 작업 내용 💻

- 유저의 유저 설정이 없는 경우 예외 처리 삭제
- 누적 공감 수 관련 타입 Long -> long으로 변경

## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 알림 누락에서 코드상에서는 문제가 없는거같아서 먼저 누적 공감 관련 변수의 타입을 변경하였는데, 여러번 테스트 결과 빠진게 없이 작동하네요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일부 알림 관련 기능에서 사용자 설정 조회 시 예외 처리가 추가되어 안정성이 향상되었습니다.
  * 리액션 수 알림 처리 시 타입 일관성이 개선되었습니다.

* **리팩터**
  * 리액션 수 알림 임계값이 확장되어 더 높은 리액션 수(10,000, 20,000, 50,000, 100,000)에도 알림이 제공됩니다.
  * 내부 코드 구조가 간결하게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->