### PR TITLE
LNK-BE-20 피드 생성일 기준 정렬

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/domain/repository/FeedRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/FeedRepository.java
@@ -15,7 +15,7 @@ public interface FeedRepository extends JpaRepository<Feed, Long> {
     @Query("SELECT f FROM Feed f JOIN FETCH f.user u WHERE f.deletedAt IS NULL AND u.id NOT IN :blockedUserIds ORDER BY f.createDate DESC")
     Slice<Feed> findAllByDeletedAtIsNullWithUser(Pageable pageable, List<Long> blockedUserIds);
 
-    @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL AND f.user = :user")
+    @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL AND f.user = :user ORDER BY f.createDate DESC")
     Slice<Feed> findAllByUserAndDeletedAtIsNull(User user, Pageable pageable);
 
     @Query("SELECT f FROM Feed f JOIN FETCH f.user WHERE f.deletedAt IS NULL AND f.id = :id")

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
@@ -15,6 +15,6 @@ public interface LinkedUserRepository extends JpaRepository<LinkedUser, Long> {
     @Query("SELECT lu FROM LinkedUser lu JOIN FETCH lu.user WHERE lu.feed = :feed order by lu.user.name asc")
     List<LinkedUser> findAllByFeed(Feed feed);
 
-    @Query("SELECT lu.feed FROM LinkedUser lu JOIN lu.feed f JOIN FETCH f.user WHERE lu.user = :user AND f.user != :user AND f.deletedAt IS NULL")
+    @Query("SELECT lu.feed FROM LinkedUser lu JOIN lu.feed f JOIN FETCH f.user WHERE lu.user = :user AND f.user != :user AND f.deletedAt IS NULL ORDER BY f.createDate DESC")
     Slice<Feed> findFeedsByLinkedUser(User user, Pageable pageable);
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #44 

## 작업 내용 💻

- 전체 조회 이외의 프로필에서 타고 피드를 조회하는 경우도 정렬이 되도록 수정했습ㄴ디ㅏ

## 스크린샷 📷
<img width="464" height="373" alt="image" src="https://github.com/user-attachments/assets/6ddb39d2-141e-4572-95d6-5b0e9838590e" />

- Id 역순이므로 최신순 정렬임을 알 수있다

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 피드 목록이 생성일 기준 내림차순으로 정렬되어 최신 피드가 먼저 표시됩니다.  
  * 연결된 사용자의 피드 조회 시에도 최신 피드가 우선적으로 보여집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->