### PR TITLE
LNK-BE-21 로그인 트리거 수정

### DIFF
--- a/src/main/java/leets/leenk/domain/user/domain/entity/User.java
+++ b/src/main/java/leets/leenk/domain/user/domain/entity/User.java
@@ -153,4 +153,8 @@ public class User extends BaseEntity {
         this.name = userInfo.name();
         this.cardinal = userInfo.cardinal();
     }
+
+    public boolean isAgree() {
+        return this.termsAgreement && this.privacyAgreement;
+    }
 }

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -66,6 +66,18 @@ public class AuthUsecase {
         if (optionalUser.isPresent()) {
             User user = optionalUser.get();
 
+            if (user.getKakaoTalkId() == null) {
+                OauthUserInfoResponse userInfo = oauthApiService.getUserInfo(response.access_token());
+
+                return loginMapper.toLoginResponse(user, userInfo, response.access_token(), response.refresh_token());
+            }
+
+            if (!user.isAgree()) {
+                OauthUserInfoResponse userInfo = oauthApiService.getUserInfo(response.access_token());
+
+                return loginMapper.toLoginResponse(user, userInfo, response.access_token(), response.refresh_token());
+            }
+
             if (user.isDeleted()) {
                 return reRegisterUser(user, response);
             }

--- a/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
+++ b/src/main/java/leets/leenk/global/auth/application/usecase/AuthUsecase.java
@@ -63,6 +63,11 @@ public class AuthUsecase {
         long userId = parseUserId(response);
         Optional<User> optionalUser = userGetService.existById(userId);
 
+        return getUserLoginResponse(optionalUser, response);
+
+    }
+
+    private LoginResponse getUserLoginResponse(Optional<User> optionalUser, OauthTokenResponse response) {
         if (optionalUser.isPresent()) {
             User user = optionalUser.get();
 


### PR DESCRIPTION
## Related issue 🛠
- closed #45 

## 작업 내용 💻

- 이용약관 미동의, 카카오톡 ID 미 입력시 로그인이 되지 않도록 수정

## 스크린샷 📷

- 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 약관 동의는 했으나 카톡 ID를 입력하지 않은 경우, 다시 처음부터 시작이라 동의를 다시 해야하는 문제는 있지만, 단계를 기억해서 제공하는 공수보다 중간에 어플을 종료하는 케이스가 더 적을 것 같아 우선 현재 방식대로 구현했습니당



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **리팩터**
  * 카카오 로그인 시 사용자의 상태(동의 여부, 탈퇴, 삭제 등)를 세분화하여 처리하도록 로직을 개선했습니다.  
  * 사용자 상태에 따라 필요한 추가 정보 요청 및 토큰 반환이 보다 명확하게 동작합니다.  
  * 사용자 동의 여부를 확인하는 기능이 추가되었습니다.  
  * 코드 가독성과 유지보수성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->