### PR TITLE
LNK-BE-22 링크 API 구현

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -1,10 +1,19 @@
 package leets.leenk.domain.feed.application.usecase;
 
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import leets.leenk.domain.feed.application.dto.request.FeedReportRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
-import leets.leenk.domain.feed.application.dto.response.*;
+import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedUserListResponse;
+import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
+import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
 import leets.leenk.domain.feed.application.exception.FeedDeleteNotAllowedException;
 import leets.leenk.domain.feed.application.exception.SelfReactionNotAllowedException;
 import leets.leenk.domain.feed.application.mapper.FeedMapper;
@@ -13,7 +22,14 @@ import leets.leenk.domain.feed.application.mapper.ReactionMapper;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.feed.domain.entity.Reaction;
-import leets.leenk.domain.feed.domain.service.*;
+import leets.leenk.domain.feed.domain.service.FeedDeleteService;
+import leets.leenk.domain.feed.domain.service.FeedGetService;
+import leets.leenk.domain.feed.domain.service.FeedSaveService;
+import leets.leenk.domain.feed.domain.service.FeedUpdateService;
+import leets.leenk.domain.feed.domain.service.LinkedUserGetService;
+import leets.leenk.domain.feed.domain.service.LinkedUserSaveService;
+import leets.leenk.domain.feed.domain.service.ReactionGetService;
+import leets.leenk.domain.feed.domain.service.ReactionSaveService;
 import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.service.MediaGetService;
@@ -31,12 +47,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +87,7 @@ public class FeedUsecase {
         Slice<Feed> slice = feedGetService.findAll(pageable, blockedUsers);
 
         List<Feed> feeds = slice.getContent();
-        List<Media> medias = mediaGetService.findAll(feeds);
+        List<Media> medias = mediaGetService.findAllByFeeds(feeds);
 
         Map<Long, List<Media>> mediaMap = medias.stream()
                 .collect(Collectors.groupingBy(media -> media.getFeed().getId()));
@@ -88,7 +98,7 @@ public class FeedUsecase {
     @Transactional(readOnly = true)
     public FeedDetailResponse getFeedDetail(Long feedId) {
         Feed feed = feedGetService.findById(feedId);
-        List<Media> medias = mediaGetService.findAll(feed);
+        List<Media> medias = mediaGetService.findAllByFeed(feed);
         List<LinkedUser> linkedUsers = linkedUserGetService.findAll(feed);
 
         return feedMapper.toFeedDetailResponse(feed, medias, linkedUsers);
@@ -177,7 +187,7 @@ public class FeedUsecase {
         User user = userGetService.findById(userId);
 
         Slice<Feed> slice = feedGetService.findAllByUser(user, pageable);
-        List<Media> medias = mediaGetService.findAll(slice.getContent());
+        List<Media> medias = mediaGetService.findAllByFeeds(slice.getContent());
 
         Map<Long, List<Media>> mediaMap = medias.stream()
                 .collect(Collectors.groupingBy(media -> media.getFeed().getId()));
@@ -191,7 +201,7 @@ public class FeedUsecase {
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
 
         Slice<Feed> slice = linkedUserGetService.findAllByUser(user, pageable);
-        List<Media> medias = mediaGetService.findAll(slice.getContent());
+        List<Media> medias = mediaGetService.findAllByFeeds(slice.getContent());
 
         Map<Long, List<Media>> mediaMap = medias.stream()
                 .collect(Collectors.groupingBy(media -> media.getFeed().getId()));

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/LeenkUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/LeenkUploadRequest.java
@@ -1,0 +1,29 @@
+package leets.leenk.domain.leenk.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record LeenkUploadRequest(
+
+        @NotNull
+        String title,
+
+        @NotNull
+        String place,
+
+        @NotNull @Schema(description = "링크 일시")
+        LocalDateTime meetingTime,
+
+        @NotNull @Min(value = 3, message = "모집 인원은 최소 3명이어야 합니다")
+        Long maxParticipants,
+
+        @NotNull
+        String content,
+
+        @NotNull
+        List<String> imageUrls
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/LeenkUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/LeenkUploadRequest.java
@@ -1,8 +1,10 @@
 package leets.leenk.domain.leenk.application.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,16 +16,19 @@ public record LeenkUploadRequest(
         @NotNull
         String place,
 
-        @NotNull @Schema(description = "링크 일시")
+        @NotNull
+        @Schema(description = "링크 일시")
         LocalDateTime meetingTime,
 
-        @NotNull @Min(value = 3, message = "모집 인원은 최소 3명이어야 합니다")
+        @NotNull
+        @Min(value = 3, message = "모집 인원은 최소 3명이어야 합니다")
+        @Max(value = 99, message = "모집 인원은 최대 99명까지 가능 합니다")
         Long maxParticipants,
 
         @NotNull
         String content,
 
-        @NotNull
+        @Size(max = 5, message = "이미지는 최대 5장까지 업로드할 수 있습니다")
         List<String> imageUrls
 ) {
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/request/LeenkUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/request/LeenkUploadRequest.java
@@ -3,22 +3,23 @@ package leets.leenk.domain.leenk.application.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record LeenkUploadRequest(
 
-        @NotNull
+        @NotBlank
         @Schema(description = "제목", example = "전정도에서 번개 고고")
         @Size(max = 30, message = "제목은 최대 30자까지 입력할 수 있습니다")
         String title,
 
-        @NotNull
-        @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~", nullable = true)
+        @NotBlank
+        @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~")
         String content,
 
-        @NotNull
+        @NotBlank
         @Schema(description = "장소명", example = "전정도")
         @Size(max = 25, message = "장소는 최대 25자까지 입력할 수 있습니다")
         String placeName,

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/request/LeenkUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/request/LeenkUploadRequest.java
@@ -6,29 +6,34 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
-import java.util.List;
 
 public record LeenkUploadRequest(
 
         @NotNull
+        @Schema(description = "제목", example = "전정도에서 번개 고고")
+        @Size(max = 30, message = "제목은 최대 30자까지 입력할 수 있습니다")
         String title,
 
         @NotNull
-        String place,
+        @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~", nullable = true)
+        String content,
 
         @NotNull
-        @Schema(description = "링크 일시")
-        LocalDateTime meetingTime,
+        @Schema(description = "장소명", example = "전정도")
+        @Size(max = 25, message = "장소는 최대 25자까지 입력할 수 있습니다")
+        String placeName,
 
         @NotNull
+        @Schema(description = "링크 일시", example = "2025-08-01T12:00:00")
+        LocalDateTime startTime,
+
+        @NotNull
+        @Schema(description = "최대 참여 인원", example = "20")
         @Min(value = 3, message = "모집 인원은 최소 3명이어야 합니다")
         @Max(value = 99, message = "모집 인원은 최대 99명까지 가능 합니다")
         Long maxParticipants,
 
-        @NotNull
-        String content,
-
-        @Size(max = 5, message = "이미지는 최대 5장까지 업로드할 수 있습니다")
-        List<String> imageUrls
+        @Schema(description = "업로드할 이미지", example = "https://s3.example.com/img1.jpg", nullable = true)
+        String mediaUrl
 ) {
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/request/LeenkUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/request/LeenkUploadRequest.java
@@ -1,4 +1,4 @@
-package leets.leenk.domain.leenk.application.dto;
+package leets.leenk.domain.leenk.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkAuthorResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkAuthorResponse.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LeenkAuthorResponse(
+        @Schema(description = "작성자 id", example = "1")
+        long userId,
+
+        @Schema(description = "프로필 이미지", example = "https://s3.example.com/profile_image.jpg")
+        String profileImage,
+
+        @Schema(description = "작성자 이름", example = "이지훈")
+        String name
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
@@ -1,0 +1,53 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LeenkDetailResponse(
+
+        @Schema(description = "링크 id", example = "1")
+        Long id,
+
+        @Schema(description = "작성자 id", example = "1")
+        Long userId,
+
+        @Schema(description = "작성자 이름", example = "이지훈")
+        String userName,
+
+        @Schema(description = "작성자 프로필 이미지 URL", example = "https://s3.example.com/user/profile.jpg", nullable = true)
+        String userProfileImage,
+
+        @Schema(description = "제목", example = "전정도에서 번개 고고")
+        String title,
+
+        @Schema(description = "장소명", example = "전정도")
+        String placeName,
+
+        @Schema(description = "현재 참여 인원", example = "3")
+        Long currentParticipants,
+
+        @Schema(description = "최대 참여 인원", example = "20")
+        Long maxParticipants,
+
+        @Schema(description = "번개 시작 시간", example = "2025-08-01T18:00:00")
+        LocalDateTime startTime,
+
+        @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~", nullable = true)
+        String content,
+
+        @Schema(description = "업로드된 이미지 URL 리스트(0~5장, 순서 보장)", example = "[\"https://s3.example.com/img1.jpg\", \"https://s3.example.com/img2.jpg\"]", nullable = true)
+        List<String> images,
+
+        @Schema(description = "생성일", example = "2025-08-01T12:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일", example = "2025-08-01T12:05:00", nullable = true)
+        LocalDateTime updatedAt
+
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
@@ -3,7 +3,6 @@ package leets.leenk.domain.leenk.application.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.Builder;
 
 @Builder
@@ -13,14 +12,8 @@ public record LeenkDetailResponse(
         @Schema(description = "링크 id", example = "1")
         Long id,
 
-        @Schema(description = "작성자 id", example = "1")
-        Long userId,
-
-        @Schema(description = "작성자 이름", example = "이지훈")
-        String userName,
-
-        @Schema(description = "작성자 프로필 이미지 URL", example = "https://s3.example.com/user/profile.jpg", nullable = true)
-        String userProfileImage,
+        @Schema(description = "작성자 정보")
+        LeenkAuthorResponse author,
 
         @Schema(description = "제목", example = "전정도에서 번개 고고")
         String title,
@@ -34,20 +27,19 @@ public record LeenkDetailResponse(
         @Schema(description = "최대 참여 인원", example = "20")
         Long maxParticipants,
 
-        @Schema(description = "번개 시작 시간", example = "2025-08-01T18:00:00")
+        @Schema(description = "링크 일시", example = "2025-08-01T18:00:00")
         LocalDateTime startTime,
 
         @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~", nullable = true)
         String content,
 
-        @Schema(description = "업로드된 이미지 URL 리스트(0~5장, 순서 보장)", example = "[\"https://s3.example.com/img1.jpg\", \"https://s3.example.com/img2.jpg\"]", nullable = true)
-        List<String> images,
+        @Schema(description = "업로드된 이미지 URL(단건)", example = "https://s3.example.com/img1.jpg", nullable = true)
+        String mediaUrl,
 
         @Schema(description = "생성일", example = "2025-08-01T12:00:00")
         LocalDateTime createdAt,
 
         @Schema(description = "수정일", example = "2025-08-01T12:05:00", nullable = true)
         LocalDateTime updatedAt
-
 ) {
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
@@ -15,6 +15,9 @@ public record LeenkDetailResponse(
         @Schema(description = "작성자 정보")
         LeenkAuthorResponse author,
 
+        @Schema(description = "카카오톡 id", example = "kakao123")
+        String kakaoId,
+
         @Schema(description = "제목", example = "전정도에서 번개 고고")
         String title,
 

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
@@ -30,7 +30,7 @@ public record LeenkDetailResponse(
         @Schema(description = "링크 일시", example = "2025-08-01T18:00:00")
         LocalDateTime startTime,
 
-        @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~", nullable = true)
+        @Schema(description = "상세 내용 (최대 200자)", example = "전정도에서 공부하실분~")
         String content,
 
         @Schema(description = "업로드된 이미지 URL(단건)", example = "https://s3.example.com/img1.jpg", nullable = true)

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkListResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkListResponse.java
@@ -1,0 +1,12 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import java.util.List;
+import leets.leenk.global.common.dto.CommonPageableResponse;
+import lombok.Builder;
+
+@Builder
+public record LeenkListResponse(
+        List<LeenkResponse> leenks,
+        CommonPageableResponse pageable
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantResponse.java
@@ -1,0 +1,33 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LeenkParticipantResponse(
+
+        @Schema(description = "링크 id")
+        Long id,
+
+        @Schema(description = "참여자 id")
+        Long userId,
+
+        @Schema(description = "참여자 이름")
+        String userName,
+
+        @Schema(description = "참여 시각")
+        LocalDateTime joinedAt,
+
+        @Schema(description = "방장 여부")
+        Boolean isHost,
+
+        @Schema(description = "생성일")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일", nullable = true)
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantResponse.java
@@ -9,9 +9,6 @@ import lombok.Builder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LeenkParticipantResponse(
 
-        @Schema(description = "링크 id")
-        Long id,
-
         @Schema(description = "참여자 id")
         Long userId,
 
@@ -22,12 +19,6 @@ public record LeenkParticipantResponse(
         LocalDateTime joinedAt,
 
         @Schema(description = "방장 여부")
-        Boolean isHost,
-
-        @Schema(description = "생성일")
-        LocalDateTime createdAt,
-
-        @Schema(description = "수정일", nullable = true)
-        LocalDateTime updatedAt
+        Boolean isHost
 ) {
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantResponse.java
@@ -9,11 +9,17 @@ import lombok.Builder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LeenkParticipantResponse(
 
-        @Schema(description = "참여자 id")
-        Long userId,
+        @Schema(description = "참여자 정보")
+        LeenkAuthorResponse participant,
 
-        @Schema(description = "참여자 이름")
-        String userName,
+        @Schema(description = "참여자 카카오톡 ID")
+        String kakaoTalkId,
+
+        @Schema(description = "현재 참여 인원", example = "3")
+        Long currentParticipants,
+
+        @Schema(description = "최대 참여 인원", example = "20")
+        Long maxParticipants,
 
         @Schema(description = "참여 시각")
         LocalDateTime joinedAt,

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantsListResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkParticipantsListResponse.java
@@ -1,0 +1,8 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import java.util.List;
+
+public record LeenkParticipantsListResponse(
+        List<LeenkParticipantResponse> participants
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
@@ -33,7 +33,7 @@ public record LeenkResponse(
         @Schema(description = "링크 수정 시간", example = "2025-08-01T12:00:00", nullable = true)
         LocalDateTime updatedAt,
 
-        @Schema(description = "링크 대표 이미지 URL(유저가 업로드한 이미지 중 첫번째)", example = "https://s3.example.com/representative_image.jpg", nullable = true)
-        String representativeImage
+        @Schema(description = "링크 이미지", example = "https://s3.example.com/representative_image.jpg", nullable = true)
+        String thumbNail
 ) {
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
@@ -1,0 +1,39 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LeenkResponse(
+
+        @Schema(description = "링크 Id", example = "1")
+        long leenkId,
+
+        @Schema(description = "유저 Id", example = "1")
+        long userId,
+
+        @Schema(description = "링크 제목")
+        String title,
+
+        @Schema(description = "현재 참여자 수", example = "2")
+        long currentParticipants,
+
+        @Schema(description = "최대 참여자 수", example = "98")
+        long maxParticipants,
+
+        @Schema(description = "링크 시작 시간", example = "2025-08-01T10:00:00")
+        LocalDateTime startTime,
+
+        @Schema(description = "링크 생성 시간", example = "2025-08-01T12:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "링크 수정 시간", example = "2025-08-01T12:00:00")
+        LocalDateTime updatedAt,
+
+        @Schema(description = "링크 대표 이미지 URL(유저가 업로드한 이미지 중 첫번째)", example = "https://s3.example.com/representative_image.jpg")
+        String representativeImage
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
@@ -30,10 +30,10 @@ public record LeenkResponse(
         @Schema(description = "링크 생성 시간", example = "2025-08-01T12:00:00")
         LocalDateTime createdAt,
 
-        @Schema(description = "링크 수정 시간", example = "2025-08-01T12:00:00")
+        @Schema(description = "링크 수정 시간", example = "2025-08-01T12:00:00", nullable = true)
         LocalDateTime updatedAt,
 
-        @Schema(description = "링크 대표 이미지 URL(유저가 업로드한 이미지 중 첫번째)", example = "https://s3.example.com/representative_image.jpg")
+        @Schema(description = "링크 대표 이미지 URL(유저가 업로드한 이미지 중 첫번째)", example = "https://s3.example.com/representative_image.jpg", nullable = true)
         String representativeImage
 ) {
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkResponse.java
@@ -12,8 +12,8 @@ public record LeenkResponse(
         @Schema(description = "링크 Id", example = "1")
         long leenkId,
 
-        @Schema(description = "유저 Id", example = "1")
-        long userId,
+        @Schema(description = "작성자 정보")
+        LeenkAuthorResponse author,
 
         @Schema(description = "링크 제목")
         String title,

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/AlreadyParticipatedException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/AlreadyParticipatedException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class AlreadyParticipatedException extends BaseException {
+    public AlreadyParticipatedException() {
+        super(ErrorCode.LEENK_ALREADY_PARTICIPATED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/CannotKickSelfException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/CannotKickSelfException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class CannotKickSelfException extends BaseException {
+    public CannotKickSelfException() {
+        super(ErrorCode.LEENK_CANNOT_KICK_SELF);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
@@ -12,7 +12,11 @@ public enum ErrorCode implements ErrorCodeInterface {
 
     LEENK_NOT_FOUND(2400, HttpStatus.NOT_FOUND, "존재하지 않는 링크입니다."),
     LEENK_STATUS_NOT_FOUND(2401, HttpStatus.NOT_FOUND, "존재하지 않는 모집글 상태입니다."),
-    LEENK_NOT_RECRUITING(2402, HttpStatus.BAD_REQUEST, "모집글이 모집 중 상태가 아닙니다.");
+    LEENK_NOT_RECRUITING(2402, HttpStatus.BAD_REQUEST, "모집글이 모집 중 상태가 아닙니다."),
+    LEENK_ALREADY_PARTICIPATED(2403, HttpStatus.BAD_REQUEST, "이미 참여한 모집글입니다."),
+    LEENK_MAX_PARTICIPANTS_EXCEEDED(2404, HttpStatus.BAD_REQUEST, "이미 모집글의 최대 참여 인원을 초과했습니다."),
+    LEENK_NOT_OWNER(2405, HttpStatus.FORBIDDEN, "해당 모집글의 작성자가(방장) 아닙니다."),
+    LEENK_ALREADY_CLOSED(2406, HttpStatus.BAD_REQUEST, "이미 마감된 모집글입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
@@ -1,0 +1,19 @@
+package leets.leenk.domain.leenk.application.exception;
+
+
+import leets.leenk.global.common.exception.ErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ErrorCodeInterface {
+
+    LEENK_NOT_FOUND(2400, HttpStatus.NOT_FOUND, "존재하지 않는 링크입니다."),
+    LEENK_STATUS_NOT_FOUND(2401, HttpStatus.NOT_FOUND, "존재하지 않는 모집글 상태입니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
@@ -16,7 +16,9 @@ public enum ErrorCode implements ErrorCodeInterface {
     LEENK_ALREADY_PARTICIPATED(2403, HttpStatus.BAD_REQUEST, "이미 참여한 모집글입니다."),
     LEENK_MAX_PARTICIPANTS_EXCEEDED(2404, HttpStatus.BAD_REQUEST, "이미 모집글의 최대 참여 인원을 초과했습니다."),
     LEENK_NOT_OWNER(2405, HttpStatus.FORBIDDEN, "해당 모집글의 작성자가(방장) 아닙니다."),
-    LEENK_ALREADY_CLOSED(2406, HttpStatus.BAD_REQUEST, "이미 마감된 모집글입니다.");
+    LEENK_ALREADY_CLOSED(2406, HttpStatus.BAD_REQUEST, "이미 마감된 모집글입니다."),
+    LEENK_CANNOT_KICK_SELF(2407, HttpStatus.BAD_REQUEST, "방장은 자신을 내보낼 수 없습니다."),
+    LEENK_PARTICIPANT_NOT_FOUND(2408, HttpStatus.NOT_FOUND, "해당 모집글에 참여하지 않은 사용자입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
@@ -11,14 +11,14 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements ErrorCodeInterface {
 
     LEENK_NOT_FOUND(2400, HttpStatus.NOT_FOUND, "존재하지 않는 링크입니다."),
-    LEENK_STATUS_NOT_FOUND(2401, HttpStatus.NOT_FOUND, "존재하지 않는 모집글 상태입니다."),
-    LEENK_NOT_RECRUITING(2402, HttpStatus.BAD_REQUEST, "모집글이 모집 중 상태가 아닙니다."),
-    LEENK_ALREADY_PARTICIPATED(2403, HttpStatus.BAD_REQUEST, "이미 참여한 모집글입니다."),
-    LEENK_MAX_PARTICIPANTS_EXCEEDED(2404, HttpStatus.BAD_REQUEST, "이미 모집글의 최대 참여 인원을 초과했습니다."),
-    LEENK_NOT_OWNER(2405, HttpStatus.FORBIDDEN, "해당 모집글의 작성자가(방장) 아닙니다."),
-    LEENK_ALREADY_CLOSED(2406, HttpStatus.BAD_REQUEST, "이미 마감된 모집글입니다."),
+    LEENK_STATUS_NOT_FOUND(2401, HttpStatus.NOT_FOUND, "존재하지 않는 링크 상태입니다."),
+    LEENK_NOT_RECRUITING(2402, HttpStatus.BAD_REQUEST, "링크가 모집 중 상태가 아닙니다."),
+    LEENK_ALREADY_PARTICIPATED(2403, HttpStatus.BAD_REQUEST, "이미 참여한 링크입니다."),
+    LEENK_MAX_PARTICIPANTS_EXCEEDED(2404, HttpStatus.BAD_REQUEST, "이미 링크의 최대 참여 인원을 초과했습니다."),
+    LEENK_NOT_OWNER(2405, HttpStatus.FORBIDDEN, "해당 링크의 작성자가(방장) 아닙니다."),
+    LEENK_ALREADY_CLOSED(2406, HttpStatus.BAD_REQUEST, "이미 마감된 링크입니다."),
     LEENK_CANNOT_KICK_SELF(2407, HttpStatus.BAD_REQUEST, "방장은 자신을 내보낼 수 없습니다."),
-    LEENK_PARTICIPANT_NOT_FOUND(2408, HttpStatus.NOT_FOUND, "해당 모집글에 참여하지 않은 사용자입니다.");
+    LEENK_PARTICIPANT_NOT_FOUND(2408, HttpStatus.NOT_FOUND, "해당 링크에 참여하지 않은 사용자입니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/ErrorCode.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements ErrorCodeInterface {
 
     LEENK_NOT_FOUND(2400, HttpStatus.NOT_FOUND, "존재하지 않는 링크입니다."),
-    LEENK_STATUS_NOT_FOUND(2401, HttpStatus.NOT_FOUND, "존재하지 않는 모집글 상태입니다.");
+    LEENK_STATUS_NOT_FOUND(2401, HttpStatus.NOT_FOUND, "존재하지 않는 모집글 상태입니다."),
+    LEENK_NOT_RECRUITING(2402, HttpStatus.BAD_REQUEST, "모집글이 모집 중 상태가 아닙니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkAlreadyClosedException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkAlreadyClosedException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class LeenkAlreadyClosedException extends BaseException {
+    public LeenkAlreadyClosedException() {
+        super(ErrorCode.LEENK_ALREADY_CLOSED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class LeenkNotFoundException extends BaseException {
+    public LeenkNotFoundException() {
+        super(ErrorCode.LEENK_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkNotRecruitingException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkNotRecruitingException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class LeenkNotRecruitingException extends BaseException {
+    public LeenkNotRecruitingException() {
+        super(ErrorCode.LEENK_NOT_RECRUITING);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkParticipantNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkParticipantNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class LeenkParticipantNotFoundException extends BaseException {
+    public LeenkParticipantNotFoundException() {
+        super(ErrorCode.LEENK_PARTICIPANT_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkStatusNotFoundException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/LeenkStatusNotFoundException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class LeenkStatusNotFoundException extends BaseException {
+    public LeenkStatusNotFoundException() {
+        super(ErrorCode.LEENK_STATUS_NOT_FOUND);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/MaxParticipantsExceededException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/MaxParticipantsExceededException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class MaxParticipantsExceededException extends BaseException {
+    public MaxParticipantsExceededException() {
+        super(ErrorCode.LEENK_MAX_PARTICIPANTS_EXCEEDED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/exception/NotLeenkOwnerException.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/exception/NotLeenkOwnerException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class NotLeenkOwnerException extends BaseException {
+    public NotLeenkOwnerException() {
+        super(ErrorCode.LEENK_NOT_OWNER);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -1,9 +1,16 @@
 package leets.leenk.domain.leenk.application.mapper;
 
-import leets.leenk.domain.leenk.application.dto.LeenkUploadRequest;
+import java.util.List;
+import java.util.Map;
+import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
+import leets.leenk.domain.leenk.application.dto.response.LeenkResponse;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.Location;
+import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.global.common.dto.PageableMapperUtil;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,6 +24,43 @@ public class LeenkMapper {
                 .content(request.content())
                 .startTime(request.meetingTime())
                 .maxParticipants(request.maxParticipants())
+                .build();
+    }
+
+    public LeenkListResponse toLeenkListResponse(Slice<Leenk> slice, Map<Long, List<Media>> mediaMap) {
+        List<LeenkResponse> responses = toLeenkResponses(slice.getContent(), mediaMap);
+
+        return LeenkListResponse.builder()
+                .leenks(responses)
+                .pageable(PageableMapperUtil.from(slice))
+                .build();
+    }
+
+    private List<LeenkResponse> toLeenkResponses(List<Leenk> leenks, Map<Long, List<Media>> mediaMap) {
+        return leenks.stream()
+                .map(leenk -> {
+                    List<Media> medias = mediaMap.getOrDefault(leenk.getId(), List.of());
+                    Media representative = medias.stream().findFirst()
+                            .orElse(null);
+
+                    return toLeenkResponse(leenk, representative);
+                })
+                .toList();
+    }
+
+    private LeenkResponse toLeenkResponse(Leenk leenk, Media representative) {
+        String imageUrl = (representative != null) ? representative.getMediaUrl() : null;
+
+        return LeenkResponse.builder()
+                .leenkId(leenk.getId())
+                .userId(leenk.getAuthor().getId())
+                .title(leenk.getTitle())
+                .currentParticipants(leenk.getCurrentParticipants())
+                .maxParticipants(leenk.getMaxParticipants())
+                .startTime(leenk.getStartTime())
+                .createdAt(leenk.getCreateDate())
+                .updatedAt(leenk.getUpdateDate())
+                .representativeImage(imageUrl)
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -76,12 +76,11 @@ public class LeenkMapper {
     }
 
     private LeenkResponse toLeenkResponse(Leenk leenk, Media representative) {
-        LeenkAuthorResponse author = toLeenkAuthorResponse(leenk);
         String imageUrl = (representative != null) ? representative.getMediaUrl() : null;
 
         return LeenkResponse.builder()
                 .leenkId(leenk.getId())
-                .userId(author.userId())
+                .author(toLeenkAuthorResponse(leenk))
                 .title(leenk.getTitle())
                 .currentParticipants(leenk.getCurrentParticipants())
                 .maxParticipants(leenk.getMaxParticipants())

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -51,6 +51,7 @@ public class LeenkMapper {
         return LeenkDetailResponse.builder()
                 .id(leenk.getId())
                 .author(toLeenkAuthorResponse(leenk))
+                .kakaoId(leenk.getAuthor().getKakaoTalkId())
                 .title(leenk.getTitle())
                 .placeName(leenk.getLocation().getPlaceName())
                 .currentParticipants(leenk.getCurrentParticipants())

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -3,6 +3,7 @@ package leets.leenk.domain.leenk.application.mapper;
 import java.util.List;
 import java.util.Map;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkAuthorResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkResponse;
@@ -23,8 +24,16 @@ public class LeenkMapper {
                 .location(location)
                 .title(request.title())
                 .content(request.content())
-                .startTime(request.meetingTime())
+                .startTime(request.startTime())
                 .maxParticipants(request.maxParticipants())
+                .build();
+    }
+
+    public LeenkAuthorResponse toLeenkAuthorResponse(Leenk leenk) {
+        return LeenkAuthorResponse.builder()
+                .userId(leenk.getAuthor().getId())
+                .profileImage(leenk.getAuthor().getProfileImage())
+                .name(leenk.getAuthor().getName())
                 .build();
     }
 
@@ -37,23 +46,18 @@ public class LeenkMapper {
                 .build();
     }
 
-    public LeenkDetailResponse toLeenkDetailResponse(Leenk leenk, List<Media> medias) {
-        List<String> imageUrls = medias.stream()
-                .map(Media::getMediaUrl)
-                .toList();
+    public LeenkDetailResponse toLeenkDetailResponse(Leenk leenk, String mediaUrl) {
 
         return LeenkDetailResponse.builder()
                 .id(leenk.getId())
-                .userId(leenk.getAuthor().getId())
-                .userName(leenk.getAuthor().getName())
-                .userProfileImage(leenk.getAuthor().getProfileImage())
+                .author(toLeenkAuthorResponse(leenk))
                 .title(leenk.getTitle())
                 .placeName(leenk.getLocation().getPlaceName())
                 .currentParticipants(leenk.getCurrentParticipants())
                 .maxParticipants(leenk.getMaxParticipants())
                 .startTime(leenk.getStartTime())
                 .content(leenk.getContent())
-                .images(imageUrls)
+                .mediaUrl(mediaUrl)
                 .createdAt(leenk.getCreateDate())
                 .updatedAt(leenk.getUpdateDate())
                 .build();
@@ -83,7 +87,7 @@ public class LeenkMapper {
                 .startTime(leenk.getStartTime())
                 .createdAt(leenk.getCreateDate())
                 .updatedAt(leenk.getUpdateDate())
-                .representativeImage(imageUrl)
+                .thumbNail(imageUrl)
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -1,0 +1,22 @@
+package leets.leenk.domain.leenk.application.mapper;
+
+import leets.leenk.domain.leenk.application.dto.LeenkUploadRequest;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.entity.Location;
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LeenkMapper {
+
+    public Leenk toLeenk(User author, Location location, LeenkUploadRequest request) {
+        return Leenk.builder()
+                .author(author)
+                .location(location)
+                .title(request.title())
+                .content(request.content())
+                .startTime(request.meetingTime())
+                .maxParticipants(request.maxParticipants())
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -76,11 +76,12 @@ public class LeenkMapper {
     }
 
     private LeenkResponse toLeenkResponse(Leenk leenk, Media representative) {
+        LeenkAuthorResponse author = toLeenkAuthorResponse(leenk);
         String imageUrl = (representative != null) ? representative.getMediaUrl() : null;
 
         return LeenkResponse.builder()
                 .leenkId(leenk.getId())
-                .userId(leenk.getAuthor().getId())
+                .userId(author.userId())
                 .title(leenk.getTitle())
                 .currentParticipants(leenk.getCurrentParticipants())
                 .maxParticipants(leenk.getMaxParticipants())

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -3,6 +3,7 @@ package leets.leenk.domain.leenk.application.mapper;
 import java.util.List;
 import java.util.Map;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkResponse;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
@@ -33,6 +34,28 @@ public class LeenkMapper {
         return LeenkListResponse.builder()
                 .leenks(responses)
                 .pageable(PageableMapperUtil.from(slice))
+                .build();
+    }
+
+    public LeenkDetailResponse toLeenkDetailResponse(Leenk leenk, List<Media> medias) {
+        List<String> imageUrls = medias.stream()
+                .map(Media::getMediaUrl)
+                .toList();
+
+        return LeenkDetailResponse.builder()
+                .id(leenk.getId())
+                .userId(leenk.getAuthor().getId())
+                .userName(leenk.getAuthor().getName())
+                .userProfileImage(leenk.getAuthor().getProfileImage())
+                .title(leenk.getTitle())
+                .placeName(leenk.getLocation().getPlaceName())
+                .currentParticipants(leenk.getCurrentParticipants())
+                .maxParticipants(leenk.getMaxParticipants())
+                .startTime(leenk.getStartTime())
+                .content(leenk.getContent())
+                .images(imageUrls)
+                .createdAt(leenk.getCreateDate())
+                .updatedAt(leenk.getUpdateDate())
                 .build();
     }
 

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.leenk.application.mapper;
+
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
+import leets.leenk.domain.user.domain.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LeenkParticipantsMapper {
+
+    public LeenkParticipants toParticipants(Leenk leenk, User user) {
+        return LeenkParticipants.builder()
+                .leenk(leenk)
+                .participant(user)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
@@ -1,5 +1,8 @@
 package leets.leenk.domain.leenk.application.mapper;
 
+import java.util.List;
+import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantResponse;
+import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import leets.leenk.domain.user.domain.entity.User;
@@ -13,5 +16,23 @@ public class LeenkParticipantsMapper {
                 .leenk(leenk)
                 .participant(user)
                 .build();
+    }
+
+    public LeenkParticipantsListResponse toLeenkParticipantsListResponse(
+            Leenk leenk,
+            List<LeenkParticipants> participants
+    ) {
+        List<LeenkParticipantResponse> responses = participants.stream()
+                .map(leenkParticipants -> LeenkParticipantResponse.builder()
+                        .id(leenk.getId())
+                        .userId(leenkParticipants.getParticipant().getId())
+                        .userName(leenkParticipants.getParticipant().getName())
+                        .joinedAt(leenkParticipants.getJoinedAt())
+                        .isHost(leenkParticipants.getParticipant().getId().equals(leenk.getAuthor().getId()))
+                        .createdAt(leenkParticipants.getCreateDate())
+                        .updatedAt(leenkParticipants.getUpdateDate())
+                        .build())
+                .toList();
+        return new LeenkParticipantsListResponse(responses);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.leenk.application.mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
@@ -11,10 +12,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class LeenkParticipantsMapper {
 
-    public LeenkParticipants toParticipants(Leenk leenk, User user) {
+    public LeenkParticipants toParticipants(Leenk leenk, User user, LocalDateTime joinedAt) {
         return LeenkParticipants.builder()
                 .leenk(leenk)
                 .participant(user)
+                .joinedAt(joinedAt)
                 .build();
     }
 

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
@@ -2,6 +2,7 @@ package leets.leenk.domain.leenk.application.mapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import leets.leenk.domain.leenk.application.dto.response.LeenkAuthorResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
@@ -20,18 +21,31 @@ public class LeenkParticipantsMapper {
                 .build();
     }
 
-    public LeenkParticipantsListResponse toLeenkParticipantsListResponse(
-            Leenk leenk,
-            List<LeenkParticipants> participants
-    ) {
+    public LeenkAuthorResponse toLeenkAuthorResponse(User user) {
+        return LeenkAuthorResponse.builder()
+                .userId(user.getId())
+                .profileImage(user.getProfileImage())
+                .name(user.getName())
+                .build();
+    }
+
+    public LeenkParticipantsListResponse toLeenkParticipantsListResponse(Leenk leenk,
+                                                                         List<LeenkParticipants> participants) {
         List<LeenkParticipantResponse> responses = participants.stream()
-                .map(leenkParticipants -> LeenkParticipantResponse.builder()
-                        .userId(leenkParticipants.getParticipant().getId())
-                        .userName(leenkParticipants.getParticipant().getName())
-                        .joinedAt(leenkParticipants.getJoinedAt())
-                        .isHost(leenkParticipants.getParticipant().getId().equals(leenk.getAuthor().getId()))
-                        .build())
+                .map(leenkParticipants -> {
+                    User participantUser = leenkParticipants.getParticipant();
+
+                    return LeenkParticipantResponse.builder()
+                            .participant(toLeenkAuthorResponse(participantUser))
+                            .kakaoTalkId(participantUser.getKakaoTalkId())
+                            .currentParticipants(leenk.getCurrentParticipants())
+                            .maxParticipants(leenk.getMaxParticipants())
+                            .joinedAt(leenkParticipants.getJoinedAt())
+                            .isHost(participantUser.getId().equals(leenk.getAuthor().getId()))
+                            .build();
+                })
                 .toList();
+
         return new LeenkParticipantsListResponse(responses);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkParticipantsMapper.java
@@ -26,13 +26,10 @@ public class LeenkParticipantsMapper {
     ) {
         List<LeenkParticipantResponse> responses = participants.stream()
                 .map(leenkParticipants -> LeenkParticipantResponse.builder()
-                        .id(leenk.getId())
                         .userId(leenkParticipants.getParticipant().getId())
                         .userName(leenkParticipants.getParticipant().getName())
                         .joinedAt(leenkParticipants.getJoinedAt())
                         .isHost(leenkParticipants.getParticipant().getId().equals(leenk.getAuthor().getId()))
-                        .createdAt(leenkParticipants.getCreateDate())
-                        .updatedAt(leenkParticipants.getUpdateDate())
                         .build())
                 .toList();
         return new LeenkParticipantsListResponse(responses);

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LocationMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LocationMapper.java
@@ -1,0 +1,14 @@
+package leets.leenk.domain.leenk.application.mapper;
+
+import leets.leenk.domain.leenk.domain.entity.Location;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationMapper {
+
+    public Location toLocation(String placeName) {
+        return Location.builder()
+                .placeName(placeName)
+                .build();
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -1,23 +1,33 @@
 package leets.leenk.domain.leenk.application.usecase;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import leets.leenk.domain.leenk.application.dto.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.mapper.LeenkMapper;
 import leets.leenk.domain.leenk.application.mapper.LeenkParticipantsMapper;
 import leets.leenk.domain.leenk.application.mapper.LocationMapper;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import leets.leenk.domain.leenk.domain.entity.Location;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
+import leets.leenk.domain.leenk.domain.service.LeenkGetService;
 import leets.leenk.domain.leenk.domain.service.LeenkParticipantsSaveService;
 import leets.leenk.domain.leenk.domain.service.LeenkSaveService;
 import leets.leenk.domain.leenk.domain.service.LocationSaveService;
 import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.service.MediaGetService;
 import leets.leenk.domain.media.domain.service.MediaSaveService;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.service.user.UserGetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,11 +36,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class LeenkUsecase {
 
     private static final int START_POSITION = 0;
-    private final UserGetService userGetService;
     private final LocationSaveService locationSaveService;
     private final LeenkSaveService leenkSaveService;
     private final LeenkParticipantsSaveService leenkParticipantsSaveService;
     private final MediaSaveService mediaSaveService;
+    private final UserGetService userGetService;
+    private final LeenkGetService leenkGetService;
+    private final MediaGetService mediaGetService;
     private final LeenkMapper leenkMapper;
     private final LeenkParticipantsMapper participantsMapper;
     private final LocationMapper locationMapper;
@@ -53,5 +65,21 @@ public class LeenkUsecase {
                 .mapToObj(i -> mediaMapper.toMedia(leenk, request.imageUrls().get(i), i))
                 .toList();
         mediaSaveService.saveAll(images);
+    }
+
+    @Transactional(readOnly = true)
+    public LeenkListResponse getLeenks(Long userId, LeenkFilter status, int pageNumber, int pageSize) {
+        userGetService.findById(userId);
+
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+
+        Slice<Leenk> slice = leenkGetService.findByStatusParam(status, pageable);
+
+        List<Leenk> leenks = slice.getContent();
+        List<Media> medias = mediaGetService.findByLeenks(leenks);
+        Map<Long, List<Media>> mediaMap = medias.stream()
+                .collect(Collectors.groupingBy(m -> m.getLeenk().getId()));
+
+        return leenkMapper.toLeenkListResponse(slice, mediaMap);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -10,6 +10,7 @@ import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
 import leets.leenk.domain.leenk.application.exception.AlreadyParticipatedException;
+import leets.leenk.domain.leenk.application.exception.CannotKickSelfException;
 import leets.leenk.domain.leenk.application.exception.LeenkAlreadyClosedException;
 import leets.leenk.domain.leenk.application.exception.LeenkNotRecruitingException;
 import leets.leenk.domain.leenk.application.exception.MaxParticipantsExceededException;
@@ -135,9 +136,32 @@ public class LeenkUsecase {
         }
 
         LeenkParticipants participant = participantsMapper.toParticipants(leenk, user, LocalDateTime.now());
-        leenkParticipantsSaveService.save(participant);
 
+        leenkParticipantsSaveService.save(participant);
         leenk.increaseCurrentParticipants();
+    }
+
+    @Transactional
+    public void kickParticipant(Long userId, Long leenkId, Long participantId) {
+        Leenk leenk = leenkGetService.findById(leenkId);
+
+        if (leenk.getStatus() != LeenkStatus.RECRUITING) {
+            throw new LeenkNotRecruitingException();
+        }
+
+        if (!leenk.getAuthor().getId().equals(userId)) {
+            throw new NotLeenkOwnerException();
+        }
+
+        if (userId.equals(participantId)) {
+            throw new CannotKickSelfException();
+        }
+
+        LeenkParticipants participant = leenkParticipantsGetService.findByLeenkAndParticipantId(leenk.getId(),
+                participantId);
+
+        leenkParticipantsSaveService.delete(participant);
+        leenk.decreaseCurrentParticipants();
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -72,8 +72,8 @@ public class LeenkUsecase {
         Leenk leenk = leenkMapper.toLeenk(author, location, request);
         leenkSaveService.save(leenk);
 
-        LeenkParticipants self = participantsMapper.toParticipants(leenk, author, LocalDateTime.now());
-        leenkParticipantsSaveService.save(self);
+        LeenkParticipants hostParticipant = participantsMapper.toParticipants(leenk, author, LocalDateTime.now());
+        leenkParticipantsSaveService.save(hostParticipant);
 
         Optional.ofNullable(request.mediaUrl())
                 .filter(StringUtils::hasText)

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -3,8 +3,8 @@ package leets.leenk.domain.leenk.application.usecase;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
@@ -24,6 +24,7 @@ import leets.leenk.domain.leenk.domain.entity.Location;
 import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
 import leets.leenk.domain.leenk.domain.entity.enums.LeenkStatus;
 import leets.leenk.domain.leenk.domain.service.LeenkGetService;
+import leets.leenk.domain.leenk.domain.service.LeenkParticipantsDeleteService;
 import leets.leenk.domain.leenk.domain.service.LeenkParticipantsGetService;
 import leets.leenk.domain.leenk.domain.service.LeenkParticipantsSaveService;
 import leets.leenk.domain.leenk.domain.service.LeenkSaveService;
@@ -41,12 +42,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 public class LeenkUsecase {
 
-    private static final int START_POSITION = 0;
     private final LocationSaveService locationSaveService;
     private final LeenkSaveService leenkSaveService;
     private final LeenkParticipantsSaveService leenkParticipantsSaveService;
@@ -55,6 +56,7 @@ public class LeenkUsecase {
     private final LeenkGetService leenkGetService;
     private final LeenkParticipantsGetService leenkParticipantsGetService;
     private final MediaGetService mediaGetService;
+    private final LeenkParticipantsDeleteService leenkParticipantsDeleteService;
     private final LeenkMapper leenkMapper;
     private final LeenkParticipantsMapper participantsMapper;
     private final LocationMapper locationMapper;
@@ -64,7 +66,7 @@ public class LeenkUsecase {
     public void uploadLeenk(Long userId, LeenkUploadRequest request) {
         User author = userGetService.findById(userId);
 
-        Location location = locationMapper.toLocation(request.place());
+        Location location = locationMapper.toLocation(request.placeName());
         locationSaveService.save(location);
 
         Leenk leenk = leenkMapper.toLeenk(author, location, request);
@@ -73,19 +75,19 @@ public class LeenkUsecase {
         LeenkParticipants self = participantsMapper.toParticipants(leenk, author, LocalDateTime.now());
         leenkParticipantsSaveService.save(self);
 
-        List<String> imageUrls = request.imageUrls() == null ? List.of() : request.imageUrls();
-        List<Media> mediaList = IntStream.range(START_POSITION, imageUrls.size())
-                .mapToObj(i -> mediaMapper.toMedia(leenk, imageUrls.get(i), i))
-                .toList();
-
-        mediaSaveService.saveAll(mediaList);
+        Optional.ofNullable(request.mediaUrl())
+                .filter(StringUtils::hasText)
+                .ifPresent(url -> {
+                    Media media = mediaMapper.toMedia(leenk, url);
+                    mediaSaveService.save(media);
+                });
     }
 
     @Transactional(readOnly = true)
     public LeenkListResponse getLeenks(Long userId, LeenkFilter status, int pageNumber, int pageSize) {
         userGetService.findById(userId);
 
-        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by("createDate").descending());
 
         Slice<Leenk> slice = leenkGetService.findByStatusParam(status, pageable);
 
@@ -100,9 +102,9 @@ public class LeenkUsecase {
     @Transactional(readOnly = true)
     public LeenkDetailResponse getLeenkDetail(Long leenkId) {
         Leenk leenk = leenkGetService.findById(leenkId);
-        List<Media> medias = mediaGetService.findByLeenk(leenk);
+        String mediaUrl = mediaGetService.findMediaUrlByLeenk(leenk);
 
-        return leenkMapper.toLeenkDetailResponse(leenk, medias);
+        return leenkMapper.toLeenkDetailResponse(leenk, mediaUrl);
     }
 
     @Transactional(readOnly = true)
@@ -118,7 +120,7 @@ public class LeenkUsecase {
     }
 
     @Transactional
-    public void participantLeenk(Long userId, Long leenkId) {
+    public void participateLeenk(Long userId, Long leenkId) {
         User user = userGetService.findById(userId);
         Leenk leenk = leenkGetService.findById(leenkId);
 
@@ -160,7 +162,7 @@ public class LeenkUsecase {
         LeenkParticipants participant = leenkParticipantsGetService.findByLeenkAndParticipantId(leenk.getId(),
                 participantId);
 
-        leenkParticipantsSaveService.delete(participant);
+        leenkParticipantsDeleteService.delete(participant);
         leenk.decreaseCurrentParticipants();
     }
 

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.mapper.LeenkMapper;
 import leets.leenk.domain.leenk.application.mapper.LeenkParticipantsMapper;
@@ -81,5 +82,13 @@ public class LeenkUsecase {
                 .collect(Collectors.groupingBy(m -> m.getLeenk().getId()));
 
         return leenkMapper.toLeenkListResponse(slice, mediaMap);
+    }
+
+    @Transactional(readOnly = true)
+    public LeenkDetailResponse getLeenkDetail(Long leenkId) {
+        Leenk leenk = leenkGetService.findById(leenkId);
+        List<Media> medias = mediaGetService.findByLeenk(leenk);
+
+        return leenkMapper.toLeenkDetailResponse(leenk, medias);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -72,10 +72,12 @@ public class LeenkUsecase {
         LeenkParticipants self = participantsMapper.toParticipants(leenk, author, LocalDateTime.now());
         leenkParticipantsSaveService.save(self);
 
-        List<Media> images = IntStream.range(START_POSITION, request.imageUrls().size())
-                .mapToObj(i -> mediaMapper.toMedia(leenk, request.imageUrls().get(i), i))
+        List<String> imageUrls = request.imageUrls() == null ? List.of() : request.imageUrls();
+        List<Media> mediaList = IntStream.range(START_POSITION, imageUrls.size())
+                .mapToObj(i -> mediaMapper.toMedia(leenk, imageUrls.get(i), i))
                 .toList();
-        mediaSaveService.saveAll(images);
+
+        mediaSaveService.saveAll(mediaList);
     }
 
     @Transactional(readOnly = true)
@@ -134,6 +136,8 @@ public class LeenkUsecase {
 
         LeenkParticipants participant = participantsMapper.toParticipants(leenk, user, LocalDateTime.now());
         leenkParticipantsSaveService.save(participant);
+
+        leenk.increaseCurrentParticipants();
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -1,0 +1,57 @@
+package leets.leenk.domain.leenk.application.usecase;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import leets.leenk.domain.leenk.application.dto.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.mapper.LeenkMapper;
+import leets.leenk.domain.leenk.application.mapper.LeenkParticipantsMapper;
+import leets.leenk.domain.leenk.application.mapper.LocationMapper;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
+import leets.leenk.domain.leenk.domain.entity.Location;
+import leets.leenk.domain.leenk.domain.service.LeenkParticipantsSaveService;
+import leets.leenk.domain.leenk.domain.service.LeenkSaveService;
+import leets.leenk.domain.leenk.domain.service.LocationSaveService;
+import leets.leenk.domain.media.application.mapper.MediaMapper;
+import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.service.MediaSaveService;
+import leets.leenk.domain.user.domain.entity.User;
+import leets.leenk.domain.user.domain.service.user.UserGetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LeenkUsecase {
+
+    private static final int START_POSITION = 0;
+    private final UserGetService userGetService;
+    private final LocationSaveService locationSaveService;
+    private final LeenkSaveService leenkSaveService;
+    private final LeenkParticipantsSaveService leenkParticipantsSaveService;
+    private final MediaSaveService mediaSaveService;
+    private final LeenkMapper leenkMapper;
+    private final LeenkParticipantsMapper participantsMapper;
+    private final LocationMapper locationMapper;
+    private final MediaMapper mediaMapper;
+
+    @Transactional
+    public void uploadLeenk(Long userId, LeenkUploadRequest request) {
+        User author = userGetService.findById(userId);
+
+        Location location = locationMapper.toLocation(request.place());
+        locationSaveService.save(location);
+
+        Leenk leenk = leenkMapper.toLeenk(author, location, request);
+        leenkSaveService.save(leenk);
+
+        LeenkParticipants self = participantsMapper.toParticipants(leenk, author);
+        leenkParticipantsSaveService.save(self);
+
+        List<Media> images = IntStream.range(START_POSITION, request.imageUrls().size())
+                .mapToObj(i -> mediaMapper.toMedia(leenk, request.imageUrls().get(i), i))
+                .toList();
+        mediaSaveService.saveAll(images);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -111,10 +111,6 @@ public class LeenkUsecase {
     public LeenkParticipantsListResponse getLeenkParticipants(Long leenkId) {
         Leenk leenk = leenkGetService.findById(leenkId);
 
-        if (leenk.getStatus() != LeenkStatus.RECRUITING) {
-            throw new LeenkNotRecruitingException();
-        }
-
         List<LeenkParticipants> participants = leenkParticipantsGetService.findAllByLeenk(leenk);
         return participantsMapper.toLeenkParticipantsListResponse(leenk, participants);
     }

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -7,6 +7,8 @@ import java.util.stream.IntStream;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
+import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
+import leets.leenk.domain.leenk.application.exception.LeenkNotRecruitingException;
 import leets.leenk.domain.leenk.application.mapper.LeenkMapper;
 import leets.leenk.domain.leenk.application.mapper.LeenkParticipantsMapper;
 import leets.leenk.domain.leenk.application.mapper.LocationMapper;
@@ -14,7 +16,9 @@ import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import leets.leenk.domain.leenk.domain.entity.Location;
 import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkStatus;
 import leets.leenk.domain.leenk.domain.service.LeenkGetService;
+import leets.leenk.domain.leenk.domain.service.LeenkParticipantsGetService;
 import leets.leenk.domain.leenk.domain.service.LeenkParticipantsSaveService;
 import leets.leenk.domain.leenk.domain.service.LeenkSaveService;
 import leets.leenk.domain.leenk.domain.service.LocationSaveService;
@@ -43,6 +47,7 @@ public class LeenkUsecase {
     private final MediaSaveService mediaSaveService;
     private final UserGetService userGetService;
     private final LeenkGetService leenkGetService;
+    private final LeenkParticipantsGetService leenkParticipantsGetService;
     private final MediaGetService mediaGetService;
     private final LeenkMapper leenkMapper;
     private final LeenkParticipantsMapper participantsMapper;
@@ -90,5 +95,17 @@ public class LeenkUsecase {
         List<Media> medias = mediaGetService.findByLeenk(leenk);
 
         return leenkMapper.toLeenkDetailResponse(leenk, medias);
+    }
+
+    @Transactional(readOnly = true)
+    public LeenkParticipantsListResponse getLeenkParticipants(Long leenkId) {
+        Leenk leenk = leenkGetService.findById(leenkId);
+
+        if (leenk.getStatus() != LeenkStatus.RECRUITING) {
+            throw new LeenkNotRecruitingException();
+        }
+
+        List<LeenkParticipants> participants = leenkParticipantsGetService.findAllByLeenk(leenk);
+        return participantsMapper.toLeenkParticipantsListResponse(leenk, participants);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.leenk.application.usecase;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -8,7 +9,11 @@ import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
+import leets.leenk.domain.leenk.application.exception.AlreadyParticipatedException;
+import leets.leenk.domain.leenk.application.exception.LeenkAlreadyClosedException;
 import leets.leenk.domain.leenk.application.exception.LeenkNotRecruitingException;
+import leets.leenk.domain.leenk.application.exception.MaxParticipantsExceededException;
+import leets.leenk.domain.leenk.application.exception.NotLeenkOwnerException;
 import leets.leenk.domain.leenk.application.mapper.LeenkMapper;
 import leets.leenk.domain.leenk.application.mapper.LeenkParticipantsMapper;
 import leets.leenk.domain.leenk.application.mapper.LocationMapper;
@@ -64,7 +69,7 @@ public class LeenkUsecase {
         Leenk leenk = leenkMapper.toLeenk(author, location, request);
         leenkSaveService.save(leenk);
 
-        LeenkParticipants self = participantsMapper.toParticipants(leenk, author);
+        LeenkParticipants self = participantsMapper.toParticipants(leenk, author, LocalDateTime.now());
         leenkParticipantsSaveService.save(self);
 
         List<Media> images = IntStream.range(START_POSITION, request.imageUrls().size())
@@ -107,5 +112,43 @@ public class LeenkUsecase {
 
         List<LeenkParticipants> participants = leenkParticipantsGetService.findAllByLeenk(leenk);
         return participantsMapper.toLeenkParticipantsListResponse(leenk, participants);
+    }
+
+    @Transactional
+    public void participantLeenk(Long userId, Long leenkId) {
+        User user = userGetService.findById(userId);
+        Leenk leenk = leenkGetService.findById(leenkId);
+
+        if (leenk.getStatus() != LeenkStatus.RECRUITING) {
+            throw new LeenkNotRecruitingException();
+        }
+
+        boolean alreadyJoined = leenkParticipantsGetService.existsByLeenkAndParticipant(leenk, user);
+        if (alreadyJoined) {
+            throw new AlreadyParticipatedException();
+        }
+
+        if (leenk.getCurrentParticipants() >= leenk.getMaxParticipants()) {
+            throw new MaxParticipantsExceededException();
+        }
+
+        LeenkParticipants participant = participantsMapper.toParticipants(leenk, user, LocalDateTime.now());
+        leenkParticipantsSaveService.save(participant);
+    }
+
+    @Transactional
+    public void closeLeenk(Long userId, Long leenkId) {
+        userGetService.findById(userId);
+        Leenk leenk = leenkGetService.findById(leenkId);
+
+        if (!leenk.getAuthor().getId().equals(userId)) {
+            throw new NotLeenkOwnerException();
+        }
+
+        if (leenk.getStatus() != LeenkStatus.RECRUITING) {
+            throw new LeenkAlreadyClosedException();
+        }
+
+        leenk.changeStatusToClosed();
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
@@ -65,6 +65,7 @@ public class Leenk extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private LeenkStatus status = LeenkStatus.RECRUITING;
 
-//    @Column(columnDefinition = "TEXT")
-//    private String imageUrls;
+    public void changeStatusToClosed() {
+        this.status = LeenkStatus.CLOSED;
+    }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
@@ -68,4 +68,8 @@ public class Leenk extends BaseEntity {
     public void changeStatusToClosed() {
         this.status = LeenkStatus.CLOSED;
     }
+
+    public void increaseCurrentParticipants() {
+        this.currentParticipants++;
+    }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
@@ -17,11 +17,14 @@ import leets.leenk.domain.leenk.domain.entity.enums.LeenkStatus;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
+@SuperBuilder
 @Table(name = "leenks")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Leenk extends BaseEntity {
@@ -53,12 +56,14 @@ public class Leenk extends BaseEntity {
     @Column(nullable = false)
     private Long maxParticipants;
 
+    @Builder.Default
     @Column(nullable = false)
-    private Long currentParticipants;
+    private Long currentParticipants = 1L;
 
+    @Builder.Default
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private LeenkStatus status;
+    private LeenkStatus status = LeenkStatus.RECRUITING;
 
 //    @Column(columnDefinition = "TEXT")
 //    private String imageUrls;

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/Leenk.java
@@ -72,4 +72,8 @@ public class Leenk extends BaseEntity {
     public void increaseCurrentParticipants() {
         this.currentParticipants++;
     }
+
+    public void decreaseCurrentParticipants() {
+        this.currentParticipants--;
+    }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/Location.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/Location.java
@@ -10,9 +10,11 @@ import leets.leenk.global.common.entity.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Entity
+@SuperBuilder
 @Table(name = "locations")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Location extends BaseEntity {

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/enums/LeenkFilter.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/enums/LeenkFilter.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum LeenkFilter {
-    ALL("전체"),
-    OPEN("모집중"),
-    CLOSED("모집완료");
+    ALL(null),
+    OPEN(LeenkStatus.RECRUITING),
+    CLOSED(LeenkStatus.CLOSED);
 
-    private final String displayValue;
+    private final LeenkStatus leenkStatus;
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/entity/enums/LeenkFilter.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/entity/enums/LeenkFilter.java
@@ -1,0 +1,14 @@
+package leets.leenk.domain.leenk.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LeenkFilter {
+    ALL("전체"),
+    OPEN("모집중"),
+    CLOSED("모집완료");
+
+    private final String displayValue;
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
@@ -3,6 +3,7 @@ package leets.leenk.domain.leenk.domain.repository;
 import java.util.List;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
+import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface LeenkParticipantsRepository extends JpaRepository<LeenkParticipants, Long> {
 
     List<LeenkParticipants> findAllByLeenk(Leenk leenk);
+
+    boolean existsByLeenkAndParticipant(Leenk leenk, User user);
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
@@ -1,6 +1,7 @@
 package leets.leenk.domain.leenk.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import leets.leenk.domain.user.domain.entity.User;
@@ -13,4 +14,6 @@ public interface LeenkParticipantsRepository extends JpaRepository<LeenkParticip
     List<LeenkParticipants> findAllByLeenk(Leenk leenk);
 
     boolean existsByLeenkAndParticipant(Leenk leenk, User user);
+
+    Optional<LeenkParticipants> findByLeenkIdAndParticipantId(Long leenkId, Long participantId);
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
@@ -1,0 +1,10 @@
+package leets.leenk.domain.leenk.domain.repository;
+
+import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeenkParticipantsRepository extends JpaRepository<LeenkParticipants, Long> {
+
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkParticipantsRepository.java
@@ -1,5 +1,7 @@
 package leets.leenk.domain.leenk.domain.repository;
 
+import java.util.List;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LeenkParticipantsRepository extends JpaRepository<LeenkParticipants, Long> {
 
+    List<LeenkParticipants> findAllByLeenk(Leenk leenk);
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkRepository.java
@@ -1,10 +1,17 @@
 package leets.leenk.domain.leenk.domain.repository;
 
+import java.util.List;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LeenkRepository extends JpaRepository<Leenk, Long> {
 
+    Slice<Leenk> findAllByStatus(LeenkStatus status, Pageable pageable);
+
+    Slice<Leenk> findAllByStatusIn(List<LeenkStatus> statuses, Pageable pageable);
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkRepository.java
@@ -1,0 +1,10 @@
+package leets.leenk.domain.leenk.domain.repository;
+
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeenkRepository extends JpaRepository<Leenk, Long> {
+
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LocationRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LocationRepository.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.leenk.domain.repository;
+
+import leets.leenk.domain.leenk.domain.entity.Location;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LocationRepository extends JpaRepository<Location, Long> {
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkGetService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkGetService.java
@@ -1,0 +1,46 @@
+package leets.leenk.domain.leenk.domain.service;
+
+import java.util.List;
+import leets.leenk.domain.leenk.application.exception.LeenkNotFoundException;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkStatus;
+import leets.leenk.domain.leenk.domain.repository.LeenkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeenkGetService {
+
+    private static final List<LeenkStatus> ALL_STATUSES = List.of(
+            LeenkStatus.RECRUITING, LeenkStatus.CLOSED
+    );
+    private final LeenkRepository leenkRepository;
+
+    public Leenk findById(Long leenkId) {
+        return leenkRepository.findById(leenkId)
+                .orElseThrow(LeenkNotFoundException::new);
+    }
+
+    public Slice<Leenk> findAll(Pageable pageable) {
+        List<LeenkStatus> statuses = List.of(LeenkStatus.RECRUITING, LeenkStatus.CLOSED);
+
+        return leenkRepository.findAllByStatusIn(statuses, pageable);
+    }
+
+    public Slice<Leenk> findByStatus(LeenkStatus status, Pageable pageable) {
+
+        return leenkRepository.findAllByStatus(status, pageable);
+    }
+
+    public Slice<Leenk> findByStatusParam(LeenkFilter status, Pageable pageable) {
+        if (status == LeenkFilter.ALL) {
+            return leenkRepository.findAllByStatusIn(ALL_STATUSES, pageable);
+        }
+        LeenkStatus leenkStatus = LeenkStatus.valueOf(status.name());
+        return leenkRepository.findAllByStatus(leenkStatus, pageable);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkGetService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkGetService.java
@@ -26,9 +26,8 @@ public class LeenkGetService {
     }
 
     public Slice<Leenk> findAll(Pageable pageable) {
-        List<LeenkStatus> statuses = List.of(LeenkStatus.RECRUITING, LeenkStatus.CLOSED);
 
-        return leenkRepository.findAllByStatusIn(statuses, pageable);
+        return leenkRepository.findAllByStatusIn(ALL_STATUSES, pageable);
     }
 
     public Slice<Leenk> findByStatus(LeenkStatus status, Pageable pageable) {
@@ -36,11 +35,11 @@ public class LeenkGetService {
         return leenkRepository.findAllByStatus(status, pageable);
     }
 
-    public Slice<Leenk> findByStatusParam(LeenkFilter status, Pageable pageable) {
-        if (status == LeenkFilter.ALL) {
+    public Slice<Leenk> findByStatusParam(LeenkFilter filter, Pageable pageable) {
+        if (filter == LeenkFilter.ALL) {
             return leenkRepository.findAllByStatusIn(ALL_STATUSES, pageable);
         }
-        LeenkStatus leenkStatus = LeenkStatus.valueOf(status.name());
-        return leenkRepository.findAllByStatus(leenkStatus, pageable);
+
+        return leenkRepository.findAllByStatus(filter.getLeenkStatus(), pageable);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsDeleteService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsDeleteService.java
@@ -7,11 +7,11 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class LeenkParticipantsSaveService {
+public class LeenkParticipantsDeleteService {
 
     private final LeenkParticipantsRepository participantsRepository;
 
-    public LeenkParticipants save(LeenkParticipants participants) {
-        return participantsRepository.save(participants);
+    public void delete(LeenkParticipants participants) {
+        participantsRepository.delete(participants);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsGetService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsGetService.java
@@ -1,6 +1,7 @@
 package leets.leenk.domain.leenk.domain.service;
 
 import java.util.List;
+import leets.leenk.domain.leenk.application.exception.LeenkParticipantNotFoundException;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import leets.leenk.domain.leenk.domain.repository.LeenkParticipantsRepository;
@@ -21,5 +22,11 @@ public class LeenkParticipantsGetService {
 
     public boolean existsByLeenkAndParticipant(Leenk leenk, User user) {
         return leenkParticipantsRepository.existsByLeenkAndParticipant(leenk, user);
+    }
+
+    public LeenkParticipants findByLeenkAndParticipantId(Long leenkId, Long participantId) {
+
+        return leenkParticipantsRepository.findByLeenkIdAndParticipantId(leenkId, participantId)
+                .orElseThrow(LeenkParticipantNotFoundException::new);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsGetService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsGetService.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.leenk.domain.service;
+
+import java.util.List;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
+import leets.leenk.domain.leenk.domain.repository.LeenkParticipantsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeenkParticipantsGetService {
+
+    private final LeenkParticipantsRepository leenkParticipantsRepository;
+
+    public List<LeenkParticipants> findAllByLeenk(Leenk leenk) {
+
+        return leenkParticipantsRepository.findAllByLeenk(leenk);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsGetService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsGetService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
 import leets.leenk.domain.leenk.domain.repository.LeenkParticipantsRepository;
+import leets.leenk.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +17,9 @@ public class LeenkParticipantsGetService {
     public List<LeenkParticipants> findAllByLeenk(Leenk leenk) {
 
         return leenkParticipantsRepository.findAllByLeenk(leenk);
+    }
+
+    public boolean existsByLeenkAndParticipant(Leenk leenk, User user) {
+        return leenkParticipantsRepository.existsByLeenkAndParticipant(leenk, user);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsSaveService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsSaveService.java
@@ -14,4 +14,8 @@ public class LeenkParticipantsSaveService {
     public LeenkParticipants save(LeenkParticipants participants) {
         return participantsRepository.save(participants);
     }
+
+    public void delete(LeenkParticipants participants) {
+        participantsRepository.delete(participants);
+    }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsSaveService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkParticipantsSaveService.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.leenk.domain.service;
+
+import leets.leenk.domain.leenk.domain.entity.LeenkParticipants;
+import leets.leenk.domain.leenk.domain.repository.LeenkParticipantsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeenkParticipantsSaveService {
+
+    private final LeenkParticipantsRepository participantsRepository;
+
+    public LeenkParticipants save(LeenkParticipants participants) {
+        return participantsRepository.save(participants);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkSaveService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkSaveService.java
@@ -11,7 +11,7 @@ public class LeenkSaveService {
 
     private final LeenkRepository leenkRepository;
 
-    public Leenk save(Leenk leenk) {
-        return leenkRepository.save(leenk);
+    public void save(Leenk leenk) {
+        leenkRepository.save(leenk);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkSaveService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkSaveService.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.leenk.domain.service;
+
+import leets.leenk.domain.leenk.domain.entity.Leenk;
+import leets.leenk.domain.leenk.domain.repository.LeenkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LeenkSaveService {
+
+    private final LeenkRepository leenkRepository;
+
+    public Leenk save(Leenk leenk) {
+        return leenkRepository.save(leenk);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LocationSaveService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LocationSaveService.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.leenk.domain.service;
+
+import leets.leenk.domain.leenk.domain.entity.Location;
+import leets.leenk.domain.leenk.domain.repository.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LocationSaveService {
+
+    private final LocationRepository locationRepository;
+
+    public Location save(Location location) {
+        return locationRepository.save(location);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -4,14 +4,18 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import leets.leenk.domain.leenk.application.dto.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.usecase.LeenkUsecase;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "LEENK")
@@ -29,5 +33,16 @@ public class LeenkController {
         leenkUsecase.uploadLeenk(userId, request);
 
         return CommonResponse.success(ResponseCode.UPLOAD_LEENK);
+    }
+
+    @GetMapping
+    @Operation(summary = "모집글 목록 조회 API [무한 스크롤]")
+    public CommonResponse<LeenkListResponse> getLeenks(@CurrentUserId @Parameter(hidden = true) Long userId,
+                                                       @RequestParam(required = false, defaultValue = "ALL") LeenkFilter status,
+                                                       @RequestParam int pageNumber,
+                                                       @RequestParam int pageSize) {
+        LeenkListResponse response = leenkUsecase.getLeenks(userId, status, pageNumber, pageSize);
+
+        return CommonResponse.success(ResponseCode.GET_ALL_LEENK, response);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -14,6 +14,7 @@ import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,6 +64,16 @@ public class LeenkController {
         LeenkParticipantsListResponse response = leenkUsecase.getLeenkParticipants(leenkId);
 
         return CommonResponse.success(ResponseCode.GET_LEENK_PARTICIPANTS, response);
+    }
+
+    @Operation(summary = "참여자 내보내기(모집중 상태) API")
+    @PatchMapping("/{leenkId}/participants/{participantId}")
+    public CommonResponse<Void> kickParticipant(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                @PathVariable Long leenkId,
+                                                @PathVariable Long participantId) {
+        leenkUsecase.kickParticipant(userId, leenkId, participantId);
+
+        return CommonResponse.success(ResponseCode.REMOVE_LEENK_PARTICIPANT);
     }
 
     @Operation(summary = "모집글 참여하기 API")

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -1,0 +1,33 @@
+package leets.leenk.domain.leenk.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import leets.leenk.domain.leenk.application.dto.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.usecase.LeenkUsecase;
+import leets.leenk.global.auth.application.annotation.CurrentUserId;
+import leets.leenk.global.common.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "LEENK")
+@RestController
+@RequestMapping("/leenks")
+@RequiredArgsConstructor
+public class LeenkController {
+
+    private final LeenkUsecase leenkUsecase;
+
+    @PostMapping
+    @Operation(summary = "모집글 작성 API")
+    public CommonResponse<Void> uploadLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                            @RequestBody @Valid LeenkUploadRequest request) {
+        leenkUsecase.uploadLeenk(userId, request);
+
+        return CommonResponse.success(ResponseCode.UPLOAD_LEENK);
+    }
+}

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -64,4 +64,22 @@ public class LeenkController {
 
         return CommonResponse.success(ResponseCode.GET_LEENK_PARTICIPANTS, response);
     }
+
+    @Operation(summary = "모집글 참여하기 API")
+    @PostMapping("/{leenkId}/participant")
+    public CommonResponse<Void> participantLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                 @PathVariable Long leenkId) {
+        leenkUsecase.participantLeenk(userId, leenkId);
+
+        return CommonResponse.success(ResponseCode.JOIN_LEENK);
+    }
+
+    @PostMapping("/{leenkId}/close")
+    @Operation(summary = "모집글 마감(모집 완료 상태) API")
+    public CommonResponse<Void> closeLeenk(@CurrentUserId @Parameter(hidden = true) Long userId,
+                                           @PathVariable Long leenkId) {
+        leenkUsecase.closeLeenk(userId, leenkId);
+
+        return CommonResponse.success(ResponseCode.CLOSE_LEENK);
+    }
 }

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.usecase.LeenkUsecase;
 import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
@@ -12,6 +13,7 @@ import leets.leenk.global.auth.application.annotation.CurrentUserId;
 import leets.leenk.global.common.response.CommonResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,7 +29,7 @@ public class LeenkController {
     private final LeenkUsecase leenkUsecase;
 
     @PostMapping
-    @Operation(summary = "모집글 작성 API")
+    @Operation(summary = "모집글(링크) 작성 API")
     public CommonResponse<Void> uploadLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
                                             @RequestBody @Valid LeenkUploadRequest request) {
         leenkUsecase.uploadLeenk(userId, request);
@@ -36,7 +38,7 @@ public class LeenkController {
     }
 
     @GetMapping
-    @Operation(summary = "모집글 목록 조회 API [무한 스크롤]")
+    @Operation(summary = "모집글(링크) 목록 조회 API [무한 스크롤]")
     public CommonResponse<LeenkListResponse> getLeenks(@CurrentUserId @Parameter(hidden = true) Long userId,
                                                        @RequestParam(required = false, defaultValue = "ALL") LeenkFilter status,
                                                        @RequestParam int pageNumber,
@@ -44,5 +46,13 @@ public class LeenkController {
         LeenkListResponse response = leenkUsecase.getLeenks(userId, status, pageNumber, pageSize);
 
         return CommonResponse.success(ResponseCode.GET_ALL_LEENK, response);
+    }
+
+    @GetMapping("/{leenkId}")
+    @Operation(summary = "모집글(링크) 상세조회 API")
+    public CommonResponse<LeenkDetailResponse> getLeenkDetail(@PathVariable Long leenkId) {
+        LeenkDetailResponse data = leenkUsecase.getLeenkDetail(leenkId);
+
+        return CommonResponse.success(ResponseCode.GET_LEENK_DETAIL, data);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -31,7 +31,7 @@ public class LeenkController {
     private final LeenkUsecase leenkUsecase;
 
     @PostMapping
-    @Operation(summary = "모집글(링크) 작성 API")
+    @Operation(summary = "링크(모집글) 작성 API")
     public CommonResponse<Void> uploadLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
                                             @RequestBody @Valid LeenkUploadRequest request) {
         leenkUsecase.uploadLeenk(userId, request);
@@ -40,7 +40,7 @@ public class LeenkController {
     }
 
     @GetMapping
-    @Operation(summary = "모집글(링크) 목록 조회 API [무한 스크롤]")
+    @Operation(summary = "링크(모집글) 목록 조회 API [무한 스크롤]")
     public CommonResponse<LeenkListResponse> getLeenks(@CurrentUserId @Parameter(hidden = true) Long userId,
                                                        @RequestParam(required = false, defaultValue = "ALL") LeenkFilter status,
                                                        @RequestParam int pageNumber,
@@ -51,7 +51,7 @@ public class LeenkController {
     }
 
     @GetMapping("/{leenkId}")
-    @Operation(summary = "모집글(링크) 상세조회 API")
+    @Operation(summary = "링크(모집글) 상세조회 API")
     public CommonResponse<LeenkDetailResponse> getLeenkDetail(@PathVariable Long leenkId) {
         LeenkDetailResponse response = leenkUsecase.getLeenkDetail(leenkId);
 
@@ -59,14 +59,14 @@ public class LeenkController {
     }
 
     @GetMapping("/{leenkId}/participants")
-    @Operation(summary = "모집글 참여자 목록 조회 API")
+    @Operation(summary = "링크(모집글) 참여자 목록 조회 API")
     public CommonResponse<LeenkParticipantsListResponse> getLeenkParticipants(@PathVariable Long leenkId) {
         LeenkParticipantsListResponse response = leenkUsecase.getLeenkParticipants(leenkId);
 
         return CommonResponse.success(ResponseCode.GET_LEENK_PARTICIPANTS, response);
     }
 
-    @Operation(summary = "참여자 내보내기(모집중 상태) API")
+    @Operation(summary = "링크(모집글) 참여자 내보내기(모집중 상태) API")
     @PatchMapping("/{leenkId}/participants/{participantId}")
     public CommonResponse<Void> kickParticipant(@Parameter(hidden = true) @CurrentUserId Long userId,
                                                 @PathVariable Long leenkId,
@@ -76,17 +76,17 @@ public class LeenkController {
         return CommonResponse.success(ResponseCode.REMOVE_LEENK_PARTICIPANT);
     }
 
-    @Operation(summary = "모집글 참여하기 API")
+    @Operation(summary = "링크(모집글) 참여하기 API")
     @PostMapping("/{leenkId}/participant")
-    public CommonResponse<Void> participantLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
+    public CommonResponse<Void> participateLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
                                                  @PathVariable Long leenkId) {
-        leenkUsecase.participantLeenk(userId, leenkId);
+        leenkUsecase.participateLeenk(userId, leenkId);
 
         return CommonResponse.success(ResponseCode.JOIN_LEENK);
     }
 
     @PostMapping("/{leenkId}/close")
-    @Operation(summary = "모집글 마감(모집 완료 상태) API")
+    @Operation(summary = "링크(모집글) 마감(모집 완료 상태) API")
     public CommonResponse<Void> closeLeenk(@CurrentUserId @Parameter(hidden = true) Long userId,
                                            @PathVariable Long leenkId) {
         leenkUsecase.closeLeenk(userId, leenkId);

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
+import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
 import leets.leenk.domain.leenk.application.usecase.LeenkUsecase;
 import leets.leenk.domain.leenk.domain.entity.enums.LeenkFilter;
 import leets.leenk.global.auth.application.annotation.CurrentUserId;
@@ -51,8 +52,16 @@ public class LeenkController {
     @GetMapping("/{leenkId}")
     @Operation(summary = "모집글(링크) 상세조회 API")
     public CommonResponse<LeenkDetailResponse> getLeenkDetail(@PathVariable Long leenkId) {
-        LeenkDetailResponse data = leenkUsecase.getLeenkDetail(leenkId);
+        LeenkDetailResponse response = leenkUsecase.getLeenkDetail(leenkId);
 
-        return CommonResponse.success(ResponseCode.GET_LEENK_DETAIL, data);
+        return CommonResponse.success(ResponseCode.GET_LEENK_DETAIL, response);
+    }
+
+    @GetMapping("/{leenkId}/participants")
+    @Operation(summary = "모집글 참여자 목록 조회 API")
+    public CommonResponse<LeenkParticipantsListResponse> getLeenkParticipants(@PathVariable Long leenkId) {
+        LeenkParticipantsListResponse response = leenkUsecase.getLeenkParticipants(leenkId);
+
+        return CommonResponse.success(ResponseCode.GET_LEENK_PARTICIPANTS, response);
     }
 }

--- a/src/main/java/leets/leenk/domain/leenk/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/ResponseCode.java
@@ -1,0 +1,23 @@
+package leets.leenk.domain.leenk.presentation;
+
+import leets.leenk.global.common.response.ResponseCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseCode implements ResponseCodeInterface {
+
+    GET_ALL_LEENK(1400, HttpStatus.OK, "전체 모집글 목록 조회에 성공했습니다."),
+    GET_LEENK_DETAIL(1401, HttpStatus.OK, "모집글 상세조회에 성공했습니다."),
+    GET_LEENK_PARTICIPANTS(1402, HttpStatus.OK, "모집글 참여자 목록 조회에 성공했습니다."),
+    UPLOAD_LEENK(1403, HttpStatus.OK, "모집글 작성에 성공했습니다."),
+
+    REMOVE_LEENK_PARTICIPANT(1404, HttpStatus.OK, "모집글 참여자 내보내기에 성공했습니다."),
+    CLOSE_LEENK(1405, HttpStatus.OK, "모집글 마감에 성공했습니다.");
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/leets/leenk/domain/leenk/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/ResponseCode.java
@@ -9,15 +9,15 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ResponseCode implements ResponseCodeInterface {
 
-    GET_ALL_LEENK(1400, HttpStatus.OK, "전체 모집글 목록 조회에 성공했습니다."),
-    GET_LEENK_DETAIL(1401, HttpStatus.OK, "모집글 상세조회에 성공했습니다."),
-    GET_LEENK_PARTICIPANTS(1402, HttpStatus.OK, "모집글 참여자 목록 조회에 성공했습니다."),
-    UPLOAD_LEENK(1403, HttpStatus.OK, "모집글 작성에 성공했습니다."),
+    GET_ALL_LEENK(1400, HttpStatus.OK, "전체 링크 목록 조회에 성공했습니다."),
+    GET_LEENK_DETAIL(1401, HttpStatus.OK, "링크 상세조회에 성공했습니다."),
+    GET_LEENK_PARTICIPANTS(1402, HttpStatus.OK, "링크 참여자 목록 조회에 성공했습니다."),
+    UPLOAD_LEENK(1403, HttpStatus.OK, "링크 작성에 성공했습니다."),
 
-    REMOVE_LEENK_PARTICIPANT(1404, HttpStatus.OK, "모집글 참여자 내보내기에 성공했습니다."),
+    REMOVE_LEENK_PARTICIPANT(1404, HttpStatus.OK, "링크 참여자 내보내기에 성공했습니다."),
 
-    JOIN_LEENK(1405, HttpStatus.OK, "모집글 참여에 성공했습니다."),
-    CLOSE_LEENK(1406, HttpStatus.OK, "모집글 마감에 성공했습니다.");
+    JOIN_LEENK(1405, HttpStatus.OK, "링크 참여에 성공했습니다."),
+    CLOSE_LEENK(1406, HttpStatus.OK, "링크 마감에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/leenk/presentation/ResponseCode.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/ResponseCode.java
@@ -15,7 +15,9 @@ public enum ResponseCode implements ResponseCodeInterface {
     UPLOAD_LEENK(1403, HttpStatus.OK, "모집글 작성에 성공했습니다."),
 
     REMOVE_LEENK_PARTICIPANT(1404, HttpStatus.OK, "모집글 참여자 내보내기에 성공했습니다."),
-    CLOSE_LEENK(1405, HttpStatus.OK, "모집글 마감에 성공했습니다.");
+
+    JOIN_LEENK(1405, HttpStatus.OK, "모집글 참여에 성공했습니다."),
+    CLOSE_LEENK(1406, HttpStatus.OK, "모집글 마감에 성공했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/media/application/mapper/MediaMapper.java
+++ b/src/main/java/leets/leenk/domain/media/application/mapper/MediaMapper.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MediaMapper {
+    private static final int DEFAULT_POSITION = 1;
 
     public Media toMedia(Feed feed, FeedMediaRequest request) {
         return Media.builder()
@@ -19,12 +20,12 @@ public class MediaMapper {
                 .build();
     }
 
-    public Media toMedia(Leenk leenk, String url, int position) {
+    public Media toMedia(Leenk leenk, String url) {
         return Media.builder()
                 .leenk(leenk)
                 .mediaUrl(url)
                 .mediaType(MediaType.IMAGE)
-                .position(position)
+                .position(DEFAULT_POSITION)
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/media/application/mapper/MediaMapper.java
+++ b/src/main/java/leets/leenk/domain/media/application/mapper/MediaMapper.java
@@ -1,8 +1,10 @@
 package leets.leenk.domain.media.application.mapper;
 
 import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
 import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.entity.enums.MediaType;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -14,6 +16,15 @@ public class MediaMapper {
                 .position(request.position())
                 .mediaUrl(request.mediaUrl())
                 .mediaType(request.mediaType())
+                .build();
+    }
+
+    public Media toMedia(Leenk leenk, String url, int position) {
+        return Media.builder()
+                .leenk(leenk)
+                .mediaUrl(url)
+                .mediaType(MediaType.IMAGE)
+                .position(position)
                 .build();
     }
 }

--- a/src/main/java/leets/leenk/domain/media/domain/entity/Media.java
+++ b/src/main/java/leets/leenk/domain/media/domain/entity/Media.java
@@ -1,7 +1,19 @@
 package leets.leenk.domain.media.domain.entity;
 
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.media.domain.entity.enums.MediaType;
@@ -15,8 +27,14 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Table(
         name = "medias",
-        indexes = @Index(name = "idx_feed_position", columnList = "feed_id, position"),
-        uniqueConstraints = @UniqueConstraint(name = "uk_feed_position", columnNames = {"feed_id", "position"})
+        indexes = {
+                @Index(name = "idx_feed_position", columnList = "feed_id, position"),
+                @Index(name = "idx_leenk_position", columnList = "leenk_id, position")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_feed_position", columnNames = {"feed_id", "position"}),
+                @UniqueConstraint(name = "uk_leenk_position", columnNames = {"leenk_id", "position"})
+        }
 )
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Media {

--- a/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
+++ b/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
@@ -1,14 +1,18 @@
 package leets.leenk.domain.media.domain.repository;
 
+import java.util.List;
 import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.media.domain.entity.Media;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface MediaRepository extends JpaRepository<Media, Long> {
 
     List<Media> findAllByFeedInOrderByPosition(List<Feed> feeds);
 
     List<Media> findAllByFeedOrderByPosition(Feed feed);
+
+    List<Media> findAllByLeenkOrderByPosition(Leenk leenk);
+
+    List<Media> findAllByLeenkInOrderByPosition(List<Leenk> leenks);
 }

--- a/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
+++ b/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
@@ -1,6 +1,7 @@
 package leets.leenk.domain.media.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.media.domain.entity.Media;
@@ -13,6 +14,8 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     List<Media> findAllByFeedOrderByPosition(Feed feed);
 
     List<Media> findAllByLeenkOrderByPosition(Leenk leenk);
+
+    Optional<Media> findFirstByLeenkOrderByPositionAsc(Leenk leenk);
 
     List<Media> findAllByLeenkInOrderByPosition(List<Leenk> leenks);
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
@@ -1,13 +1,13 @@
 package leets.leenk.domain.media.domain.service;
 
+import java.util.List;
 import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.media.application.exception.MediaNotFoundException;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +20,19 @@ public class MediaGetService {
                 .orElseThrow(MediaNotFoundException::new);
     }
 
-    public List<Media> findAll(Feed feed) {
+    public List<Media> findAllByFeed(Feed feed) {
         return mediaRepository.findAllByFeedOrderByPosition(feed);
     }
 
-    public List<Media> findAll(List<Feed> feeds) {
+    public List<Media> findAllByFeeds(List<Feed> feeds) {
         return mediaRepository.findAllByFeedInOrderByPosition(feeds);
+    }
+
+    public List<Media> findByLeenk(Leenk leenk) {
+        return mediaRepository.findAllByLeenkOrderByPosition(leenk);
+    }
+
+    public List<Media> findByLeenks(List<Leenk> leenks) {
+        return mediaRepository.findAllByLeenkInOrderByPosition(leenks);
     }
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaGetService.java
@@ -28,8 +28,11 @@ public class MediaGetService {
         return mediaRepository.findAllByFeedInOrderByPosition(feeds);
     }
 
-    public List<Media> findByLeenk(Leenk leenk) {
-        return mediaRepository.findAllByLeenkOrderByPosition(leenk);
+    public String findMediaUrlByLeenk(Leenk leenk) {
+        return mediaRepository
+                .findFirstByLeenkOrderByPositionAsc(leenk)
+                .map(Media::getMediaUrl)
+                .orElse("");
     }
 
     public List<Media> findByLeenks(List<Leenk> leenks) {

--- a/src/main/java/leets/leenk/global/config/JpaConfig.java
+++ b/src/main/java/leets/leenk/global/config/JpaConfig.java
@@ -7,9 +7,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @Configuration
 @EnableJpaAuditing
 @EnableJpaRepositories(basePackages = {
-	"leets.leenk.domain.feed.domain.repository",
-	"leets.leenk.domain.user.domain.repository",
-	"leets.leenk.domain.media.domain.repository"
+        "leets.leenk.domain.feed.domain.repository",
+        "leets.leenk.domain.user.domain.repository",
+        "leets.leenk.domain.media.domain.repository",
+        "leets.leenk.domain.leenk.domain.repository",
 })
 public class JpaConfig {
 }


### PR DESCRIPTION
## Related issue 🛠
- closed #48 

## 작업 내용 💻

- [x] 모집글(링크) 작성 `API` - (`POST`)

- [x] 모집글(링크) 목록 조회 `API` - (`GET`, 전체/모집중/모집완료 필터)
존재하지 않는 `leenkId`로 상세 조회시 -> 존재하지 않는 링크입니다
존재하지 않는 상태값(`status`)으로 목록 조회 -> 존재하지 않는 모집글 상태입니다

- [x] 모집글(링크) 상세 조회 `API` - (`GET`)
존재하지 않는 `leenkId`로 상세 조회시 -> 존재하지 않는 링크입니다

- [x] 모집글(링크) 참여자 목록 조회 `API` - (`GET`)
모집글이 모집중(`RECRUITING`)이 아닐 때 참여자 조회 시도 -> 모집글이 모집 중 상태가 아닙니다 (불필요한 예외처리임)
-> 예외처리를 하면 안되는 이유 : 모집 완료인 상태여도, 참여자를 조회할 수 있어야되기때문

- [x] 모집글(링크) 참여자 내보내기 `API` - (`PATCH`)
모집글이 모집중(`RECRUITING`)이 아닐 때 참여자 내보내기 시도 -> 모집글이 모집 중 상태가 아닙니다
방장이 아닌유저 + 작성자 아닌 사용자가 내보내기 시도 -> 해당 모집글의 작성자가(방장) 아닙니다
방장+ 작성자가 본인 내보내기 시도 -> 본인은 내보낼 수 없습니다

- [x] 모집글(링크) 참여하기 `API` - (`POST`)
모집글이 모집중(`RECRUITING`)이 아닐 때 참여자 참여 시도 -> 모집글이 모집 중 상태가 아닙니다
이미 참여 중인 사용자가 다시 참여를 시도 -> 이미 참여한 모집글입니다
이미 최대 인원을 초과했는데 참여를 시도 -> 이미 모집글의 최대 참여 인원을 초과했습니다

- [x] 모집글(링크) 마감 `API` -  (`POST`)
모집글이 모집중(`RECRUITING`)이 아닐 때 참여자 마감 시도 -> 모집글이 모집 중 상태가 아닙니다
방장이 아닌유저 + 작성자 아닌 사용자가 마감 시도 -> 해당 모집글의 작성자가(방장) 아닙니다
이미 마감된 모집글에 또 마감 요청 -> 이미 마감된 모집글입니다

## 스크린샷 📷

DB에 더미데이터 넣어서 모든 케이스 테스트 완료했습니다

<img width="1324" height="256" alt="image" src="https://github.com/user-attachments/assets/9b2315e0-f291-4698-91dd-7ad1b35f7f1d" />

<img width="1243" height="281" alt="image" src="https://github.com/user-attachments/assets/35217111-4005-491b-ba1b-d9442683fcd0" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 작업 스프린트 속도를 빠르게 냈어야해서 한개 PR로 작성하게 되었습니다. 커밋 단위로 예외처리 제가 적어놓은 내용들 위주로 봐주시고 빠진 내용들이나 요구사항에 맞지않는 부분 모두 남겨주시면 감사할거같아요 🙇🏻‍♂️
+ 피그마 뷰에 방장이 아닌 유저가 모집 상태인 링크를 떠나는 뷰가 없어서, 피그마에 일단 댓글로 남겨놨는데 회의때 다같이 얘기해봐요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * "Leenk" 모집글 생성, 상세 조회, 목록 조회, 참여자 목록 조회, 참여, 모집 마감, 참여자 강제 퇴장 기능 추가
  * 모집글 관련 REST API 엔드포인트 제공 및 유효성 검증 강화 (제목, 장소, 일시, 최대 인원, 내용, 이미지)
  * 미디어 이미지 연동 및 대표 이미지 조회 기능 포함
  * 페이징 및 상태별 필터링 기능 지원

* **오류 처리 및 예외**
  * 모집글 상태, 참여 중복, 최대 인원 초과, 비소유자 접근, 자기 자신 강제 퇴장 불가 등 상세 예외 처리 및 오류 코드 추가

* **응답 및 문서화**
  * 모집글 및 참여자 응답 DTO에 Swagger 문서화 및 예시 값 포함
  * 성공/실패 응답 코드 및 메시지 명확화

* **기타**
  * 도메인 엔티티에 빌더 패턴 적용 및 기본값 설정
  * 데이터 매핑, 저장, 조회를 위한 매퍼 및 서비스 계층 구현
  * JPA 리포지토리 스캔 범위 확장 및 미디어 관련 인덱스 및 제약조건 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->