### PR TITLE
LNK-BE-25 피드 수정

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
@@ -1,4 +1,22 @@
 package leets.leenk.domain.feed.application.dto.request;
 
-public record FeedUpdateRequest() {
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
+
+import java.util.List;
+
+public record FeedUpdateRequest(
+        @Schema(description = "피드 설명", example = "행복한 링크 생활 (수정할 값만 보내주세요)")
+        @Size(max = 100)
+        String description,
+
+        @Valid
+        @Size(max = 3)
+        List<FeedMediaRequest> media,
+
+        @Schema(description = "함께한 사용자 목록 (수정할 값만 보내주세요)")
+        List<Long> userId
+) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
@@ -17,6 +17,6 @@ public record FeedUpdateRequest(
         List<FeedMediaRequest> media,
 
         @Schema(description = "함께한 사용자 목록 (수정할 값만 보내주세요)")
-        List<Long> userId
+        List<Long> userIds
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
@@ -19,6 +19,6 @@ public record FeedUploadRequest(
         List<FeedMediaRequest> media,
 
         @Schema(description = "함께한 사용자 목록")
-        List<Long> userId
+        List<Long> userIds
 ) {
 }

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public record FeedUploadRequest(
         @Schema(description = "피드 설명", example = "행복한 링크 생활")
+        @Size(max = 100)
         String description,
 
         @Valid

--- a/src/main/java/leets/leenk/domain/feed/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/feed/application/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode implements ErrorCodeInterface {
 
     FEED_NOT_FOUND(2200, HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다."),
     SELF_REACTION(2202, HttpStatus.FORBIDDEN, "자신의 피드에 공감할 수 없습니다."),
-    FEED_DELETE_NOT_ALLOWED(2203, HttpStatus.FORBIDDEN, "피드 삭제는 작성자만 가능합니다.");
+    FEED_DELETE_NOT_ALLOWED(2203, HttpStatus.FORBIDDEN, "피드 삭제는 작성자만 가능합니다."),
+    FEED_UPDATE_NOT_ALLOWED(2204, HttpStatus.FORBIDDEN, "피드 수정은 작성자만 가능합니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/feed/application/exception/FeedUpdateNotAllowedException.java
+++ b/src/main/java/leets/leenk/domain/feed/application/exception/FeedUpdateNotAllowedException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.feed.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class FeedUpdateNotAllowedException extends BaseException {
+    public FeedUpdateNotAllowedException() {
+        super(ErrorCode.FEED_UPDATE_NOT_ALLOWED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -109,7 +109,7 @@ public class FeedUsecase {
                 .toList();
         mediaSaveService.saveAll(medias);
 
-        List<LinkedUser> linkedUsers = getLinkedUsers(author, request.userId(), feed);
+        List<LinkedUser> linkedUsers = getLinkedUsers(author, request.userIds(), feed);
         linkedUserSaveService.saveAll(linkedUsers);
 
         notificationUsecase.saveNewFeedNotification(feed);
@@ -180,9 +180,9 @@ public class FeedUsecase {
             mediaSaveService.saveAll(newMedias);
         }
 
-        if (request.userId() != null) {
+        if (request.userIds() != null) {
             linkedUserDeleteService.deleteAllByFeed(feed);
-            List<LinkedUser> newLinkedUsers = getLinkedUsers(author, request.userId(), feed);
+            List<LinkedUser> newLinkedUsers = getLinkedUsers(author, request.userIds(), feed);
             linkedUserSaveService.saveAll(newLinkedUsers);
         }
     }

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -1,20 +1,12 @@
 package leets.leenk.domain.feed.application.usecase;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import leets.leenk.domain.feed.application.dto.request.FeedReportRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.application.dto.request.FeedUploadRequest;
 import leets.leenk.domain.feed.application.dto.request.ReactionRequest;
-import leets.leenk.domain.feed.application.dto.response.FeedDetailResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedListResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedUserListResponse;
-import leets.leenk.domain.feed.application.dto.response.FeedUserResponse;
-import leets.leenk.domain.feed.application.dto.response.ReactionUserResponse;
+import leets.leenk.domain.feed.application.dto.response.*;
 import leets.leenk.domain.feed.application.exception.FeedDeleteNotAllowedException;
+import leets.leenk.domain.feed.application.exception.FeedUpdateNotAllowedException;
 import leets.leenk.domain.feed.application.exception.SelfReactionNotAllowedException;
 import leets.leenk.domain.feed.application.mapper.FeedMapper;
 import leets.leenk.domain.feed.application.mapper.FeedUserMapper;
@@ -22,16 +14,10 @@ import leets.leenk.domain.feed.application.mapper.ReactionMapper;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.feed.domain.entity.Reaction;
-import leets.leenk.domain.feed.domain.service.FeedDeleteService;
-import leets.leenk.domain.feed.domain.service.FeedGetService;
-import leets.leenk.domain.feed.domain.service.FeedSaveService;
-import leets.leenk.domain.feed.domain.service.FeedUpdateService;
-import leets.leenk.domain.feed.domain.service.LinkedUserGetService;
-import leets.leenk.domain.feed.domain.service.LinkedUserSaveService;
-import leets.leenk.domain.feed.domain.service.ReactionGetService;
-import leets.leenk.domain.feed.domain.service.ReactionSaveService;
+import leets.leenk.domain.feed.domain.service.*;
 import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
+import leets.leenk.domain.media.domain.service.MediaDeleteService;
 import leets.leenk.domain.media.domain.service.MediaGetService;
 import leets.leenk.domain.media.domain.service.MediaSaveService;
 import leets.leenk.domain.notification.application.usecase.NotificationUsecase;
@@ -47,6 +33,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -64,9 +56,11 @@ public class FeedUsecase {
 
     private final MediaGetService mediaGetService;
     private final MediaSaveService mediaSaveService;
+    private final MediaDeleteService mediaDeleteService;
 
     private final LinkedUserGetService linkedUserGetService;
     private final LinkedUserSaveService linkedUserSaveService;
+    private final LinkedUserDeleteService linkedUserDeleteService;
 
     private final ReactionGetService reactionGetService;
     private final ReactionSaveService reactionSaveService;
@@ -169,7 +163,28 @@ public class FeedUsecase {
                 .toList();
     }
 
-    public void updateFeed(FeedUpdateRequest request) {
+    @Transactional
+    public void updateFeed(long userId, long feedId, FeedUpdateRequest request) {
+        Feed feed = feedGetService.findById(feedId);
+        User author = userGetService.findById(userId);
+
+        checkAuthor(author, feed);
+
+        feedUpdateService.update(feed, request);
+
+        if (request.media() != null) {
+            mediaDeleteService.deleteAllByFeed(feed);
+            List<Media> newMedias = request.media().stream()
+                    .map(mediaRequest -> mediaMapper.toMedia(feed, mediaRequest))
+                    .toList();
+            mediaSaveService.saveAll(newMedias);
+        }
+
+        if (request.userId() != null) {
+            linkedUserDeleteService.deleteAllByFeed(feed);
+            List<LinkedUser> newLinkedUsers = getLinkedUsers(author, request.userId(), feed);
+            linkedUserSaveService.saveAll(newLinkedUsers);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -254,6 +269,12 @@ public class FeedUsecase {
             if (previous < milestone && current >= milestone) {
                 notificationUsecase.saveReactionCountNotification(feed, milestone);
             }
+        }
+    }
+
+    private void checkAuthor(User user, Feed feed) {
+        if (!feed.getUser().equals(user)) {
+            throw new FeedUpdateNotAllowedException();
         }
     }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/entity/Feed.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/entity/Feed.java
@@ -40,4 +40,8 @@ public class Feed extends BaseEntity {
     public void delete() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/repository/LinkedUserRepository.java
@@ -17,4 +17,6 @@ public interface LinkedUserRepository extends JpaRepository<LinkedUser, Long> {
 
     @Query("SELECT lu.feed FROM LinkedUser lu JOIN lu.feed f JOIN FETCH f.user WHERE lu.user = :user AND f.user != :user AND f.deletedAt IS NULL ORDER BY f.createDate DESC")
     Slice<Feed> findFeedsByLinkedUser(User user, Pageable pageable);
+
+    void deleteAllByFeed(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
@@ -1,12 +1,20 @@
 package leets.leenk.domain.feed.domain.service;
 
+import leets.leenk.domain.feed.application.dto.request.FeedUpdateRequest;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.feed.domain.entity.Reaction;
 import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 public class FeedUpdateService {
+
+    public void update(Feed feed, FeedUpdateRequest request) {
+        Optional.ofNullable(request.description())
+                .ifPresent(feed::updateDescription);
+    }
 
     public void updateTotalReaction(Feed feed, Reaction reaction, User user, long reactionCount) {
         feed.increaseTotalReactionCount(reactionCount);

--- a/src/main/java/leets/leenk/domain/feed/domain/service/LinkedUserDeleteService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/LinkedUserDeleteService.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.feed.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.feed.domain.repository.LinkedUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LinkedUserDeleteService {
+
+    private final LinkedUserRepository linkedUserRepository;
+
+    @Transactional
+    public void deleteAllByFeed(Feed feed) {
+        linkedUserRepository.deleteAllByFeed(feed);
+        linkedUserRepository.flush();
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
+++ b/src/main/java/leets/leenk/domain/feed/presentation/FeedController.java
@@ -71,11 +71,12 @@ public class FeedController {
         return CommonResponse.success(ResponseCode.GET_REACTED_USERS, response);
     }
 
-    @PatchMapping
+    @PatchMapping("/{feedId}")
     @Operation(summary = "피드 수정 API")
     public CommonResponse<Void> updateFeed(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                           @PathVariable @Positive long feedId,
                                            @RequestBody @Valid FeedUpdateRequest request) {
-        feedUsecase.updateFeed(request);
+        feedUsecase.updateFeed(userId, feedId, request);
 
         return CommonResponse.success(ResponseCode.UPDATE_FEED);
     }

--- a/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
+++ b/src/main/java/leets/leenk/domain/media/domain/repository/MediaRepository.java
@@ -1,11 +1,12 @@
 package leets.leenk.domain.media.domain.repository;
 
-import java.util.List;
-import java.util.Optional;
 import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.media.domain.entity.Media;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface MediaRepository extends JpaRepository<Media, Long> {
 
@@ -18,4 +19,6 @@ public interface MediaRepository extends JpaRepository<Media, Long> {
     Optional<Media> findFirstByLeenkOrderByPositionAsc(Leenk leenk);
 
     List<Media> findAllByLeenkInOrderByPosition(List<Leenk> leenks);
+
+    void deleteAllByFeed(Feed feed);
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaDeleteService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaDeleteService.java
@@ -1,10 +1,12 @@
 package leets.leenk.domain.media.domain.service;
 
-import java.util.List;
+import leets.leenk.domain.feed.domain.entity.Feed;
 import leets.leenk.domain.media.domain.entity.Media;
 import leets.leenk.domain.media.domain.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,5 +20,10 @@ public class MediaDeleteService {
 
     public void deleteAll(List<Media> mediaList) {
         mediaRepository.deleteAll(mediaList);
+    }
+
+    public void deleteAllByFeed(Feed feed) {
+        mediaRepository.deleteAllByFeed(feed);
+        mediaRepository.flush();
     }
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaDeleteService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaDeleteService.java
@@ -1,0 +1,20 @@
+package leets.leenk.domain.media.domain.service;
+
+import leets.leenk.domain.feed.domain.entity.Feed;
+import leets.leenk.domain.media.domain.repository.MediaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MediaDeleteService {
+
+    private final MediaRepository mediaRepository;
+
+    @Transactional
+    public void deleteAllByFeed(Feed feed) {
+        mediaRepository.deleteAllByFeed(feed);
+        mediaRepository.flush();
+    }
+}

--- a/src/main/java/leets/leenk/domain/notification/domain/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/repository/NotificationRepositoryImpl.java
@@ -1,15 +1,14 @@
 package leets.leenk.domain.notification.domain.repository;
 
-import java.util.Optional;
-
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.stereotype.Repository;
-import org.springframework.data.mongodb.core.query.Query;
-import lombok.RequiredArgsConstructor;
-
 import leets.leenk.domain.notification.domain.entity.Notification;
 import leets.leenk.domain.notification.domain.entity.NotificationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -29,7 +28,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
                                                                         Long userId) {
         Query query = new Query(Criteria.where("notificationType").is(type)
                 .and("content.feedId").is(feedId)
-                .and("content.feedFirstReactions.userId").is(userId));
+                .and("content.feedFirstReactions.userIds").is(userId));
         return Optional.ofNullable(mongoTemplate.findOne(query, Notification.class));
     }
 

--- a/src/main/java/leets/leenk/domain/notification/domain/repository/NotificationRepositoryImpl.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/repository/NotificationRepositoryImpl.java
@@ -28,7 +28,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
                                                                         Long userId) {
         Query query = new Query(Criteria.where("notificationType").is(type)
                 .and("content.feedId").is(feedId)
-                .and("content.feedFirstReactions.userIds").is(userId));
+                .and("content.feedFirstReactions.userId").is(userId));
         return Optional.ofNullable(mongoTemplate.findOne(query, Notification.class));
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed 

## 작업 내용 💻

- 피드 수정 API를 구현했습니다
- PATCH에 맞게 들어온 값만 수정되도록 했습니다
- 연관관계가 있는 경우 삭제하고 다시 저장되도록 했으며, delete 연산이 lazy하게 돌아가기 때문에 서비스 단에서 flush()를 해줌으로 DB 유니크 제약조건을 지키도록 구현했습니다

## 스크린샷 📷

- 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 피드 수정 API가 /feeds/{feedId}로 변경되어 특정 피드를 수정합니다.
  * 수정/업로드 요청에 description, media(최대 3개), userIds(태깅 대상 다중 지정) 필드가 반영됩니다.
* **버그 픽스 / 동작 변경**
  * 수정 시 기존 미디어와 태깅 목록을 전부 교체합니다.
  * 작성자가 아닐 경우 수정이 거부되어 권한 오류가 발생합니다(관련 예외/오류코드 추가).
* **문서**
  * 필드 제약(설명 100자 제한 등) 및 API 메타데이터가 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->