### PR TITLE
LNK-BE-26 피드 미디어 관련 validation 추가

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
@@ -2,6 +2,8 @@ package leets.leenk.domain.feed.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
 
@@ -13,7 +15,9 @@ public record FeedUpdateRequest(
         String description,
 
         @Valid
-        @Size(max = 3)
+        @NotNull
+        @NotEmpty
+        @Size(min = 1, max = 3)
         List<FeedMediaRequest> media,
 
         @Schema(description = "함께한 사용자 목록 (수정할 값만 보내주세요)")

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUpdateRequest.java
@@ -2,8 +2,6 @@ package leets.leenk.domain.feed.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
 
@@ -15,8 +13,6 @@ public record FeedUpdateRequest(
         String description,
 
         @Valid
-        @NotNull
-        @NotEmpty
         @Size(min = 1, max = 3)
         List<FeedMediaRequest> media,
 

--- a/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
+++ b/src/main/java/leets/leenk/domain/feed/application/dto/request/FeedUploadRequest.java
@@ -2,6 +2,7 @@ package leets.leenk.domain.feed.application.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
@@ -15,7 +16,8 @@ public record FeedUploadRequest(
 
         @Valid
         @NotNull
-        @Size(max = 3)
+        @NotEmpty
+        @Size(min = 1, max = 3)
         List<FeedMediaRequest> media,
 
         @Schema(description = "함께한 사용자 목록")


### PR DESCRIPTION
## Related issue 🛠
- closed #56 

## 작업 내용 💻

- media가 없는 경우 feed가 저장되는 문제를 해결했습니다
- 아래 형태로 요청이 들어오면 feed가 저장 되고 있었는데, upload, update dto에 @NotEmpty, min 설정을 통해 예외 케이스를 해결했습니다

```
{
  "description": "행복한 링크 생활",
  "media": [

  ]
}
```

## 스크린샷 📷

- 

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

-



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 피드 업로드/수정 시 미디어가 누락되거나 비어 있는 요청을 차단하도록 검증을 강화했습니다.
  - 미디어 첨부 개수를 명확히 1–3개로 제한하고, 범위를 벗어나면 즉시 검증 오류를 반환합니다.
  - 업로드와 수정 양쪽에 동일한 유효성 검사를 적용해 동작의 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->