### PR TITLE
LNK-BE-27 피드 설명 개행 제거

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
+++ b/src/main/java/leets/leenk/domain/feed/application/mapper/FeedMapper.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.Map;
 
+import static leets.leenk.domain.feed.application.util.FeedDescriptionUtil.normalizeDescription;
+
 @Component
 public class FeedMapper {
 
@@ -64,9 +66,11 @@ public class FeedMapper {
     }
 
     public Feed toFeed(User user, String description) {
+        String normalizedDescription = normalizeDescription(description);
+
         return Feed.builder()
                 .user(user)
-                .description(description)
+                .description(normalizedDescription)
                 .build();
     }
 

--- a/src/main/java/leets/leenk/domain/feed/application/util/FeedDescriptionUtil.java
+++ b/src/main/java/leets/leenk/domain/feed/application/util/FeedDescriptionUtil.java
@@ -1,0 +1,11 @@
+package leets.leenk.domain.feed.application.util;
+
+
+public class FeedDescriptionUtil {
+    public static String normalizeDescription(String description) {
+        if (description == null) return null;
+        String trimmed = description.replaceFirst("^(\r\n|\n)+", "");
+
+        return trimmed.replaceAll("(\r\n|\n){2,}", "\n");
+    }
+}

--- a/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
+++ b/src/main/java/leets/leenk/domain/feed/domain/service/FeedUpdateService.java
@@ -8,11 +8,14 @@ import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+import static leets.leenk.domain.feed.application.util.FeedDescriptionUtil.normalizeDescription;
+
 @Service
 public class FeedUpdateService {
 
     public void update(Feed feed, FeedUpdateRequest request) {
-        Optional.ofNullable(request.description())
+        String normalized = normalizeDescription(request.description());
+        Optional.ofNullable(normalized)
                 .ifPresent(feed::updateDescription);
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #58 

## 작업 내용 💻

- 피드 설명에 불 필요한 개행이 들어간 경우 제거했습니다
- 1. 개행만으로 시작하다 글자가 나타나는 경우
- 2. 글자 사이사이 개행이 2번씩 들어간 경우 1번으로 변경

## 스크린샷 📷

 
<img width="919" height="592" alt="image" src="https://github.com/user-attachments/assets/04837dff-1912-4514-8038-a172465d7742" />

<img width="425" height="380" alt="image" src="https://github.com/user-attachments/assets/8e78e831-b115-4847-b6d3-65ae83840fb3" />

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- replace가 내부 동작상 빠른 메서드는 아니지만 크게 성능을 좌우할 부분은 아니라 생각해 빠르게 수정 했습니당



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 피드 설명에 앞부분의 빈 줄이 남거나 줄바꿈이 과도하게 누적되어 보이던 문제를 수정했습니다.
  - 피드 생성·수정 시 설명을 자동으로 정규화하여 연속 개행을 한 줄로 통합하고 불필요한 공백을 제거합니다.
  - 이를 통해 목록과 상세 화면에서 설명 레이아웃이 일관되고 읽기 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->