### PR TITLE
LNK-BE-28 링크 상세조회, 생성 응답 dto 수정

### DIFF
--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkCreateResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkCreateResponse.java
@@ -1,0 +1,10 @@
+package leets.leenk.domain.leenk.application.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LeenkCreateResponse(
+
+        @Schema(description = "생성된 링크 id", example = "1")
+        Long id
+) {
+}

--- a/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/dto/response/LeenkDetailResponse.java
@@ -3,6 +3,7 @@ package leets.leenk.domain.leenk.application.dto.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import leets.leenk.domain.leenk.domain.entity.enums.LeenkStatus;
 import lombok.Builder;
 
 @Builder
@@ -17,6 +18,9 @@ public record LeenkDetailResponse(
 
         @Schema(description = "카카오톡 id", example = "kakao123")
         String kakaoId,
+
+        @Schema(description = "링크 상태", example = "RECRUITING")
+        LeenkStatus status,
 
         @Schema(description = "제목", example = "전정도에서 번개 고고")
         String title,

--- a/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/mapper/LeenkMapper.java
@@ -52,6 +52,7 @@ public class LeenkMapper {
                 .id(leenk.getId())
                 .author(toLeenkAuthorResponse(leenk))
                 .kakaoId(leenk.getAuthor().getKakaoTalkId())
+                .status(leenk.getStatus())
                 .title(leenk.getTitle())
                 .placeName(leenk.getLocation().getPlaceName())
                 .currentParticipants(leenk.getCurrentParticipants())

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import leets.leenk.domain.leenk.application.dto.request.LeenkReportRequest;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUpdateRequest;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkCreateResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
@@ -83,7 +84,7 @@ public class LeenkUsecase {
     private final MediaMapper mediaMapper;
 
     @Transactional
-    public void uploadLeenk(Long userId, LeenkUploadRequest request) {
+    public LeenkCreateResponse uploadLeenk(Long userId, LeenkUploadRequest request) {
         User author = userGetService.findById(userId);
 
         Location location = locationMapper.toLocation(request.placeName());
@@ -101,6 +102,8 @@ public class LeenkUsecase {
                     Media media = mediaMapper.toMedia(leenk, url);
                     mediaSaveService.save(media);
                 });
+
+        return new LeenkCreateResponse(leenk.getId());
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
+++ b/src/main/java/leets/leenk/domain/leenk/presentation/LeenkController.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Positive;
 import leets.leenk.domain.leenk.application.dto.request.LeenkReportRequest;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUpdateRequest;
 import leets.leenk.domain.leenk.application.dto.request.LeenkUploadRequest;
+import leets.leenk.domain.leenk.application.dto.response.LeenkCreateResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkDetailResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkListResponse;
 import leets.leenk.domain.leenk.application.dto.response.LeenkParticipantsListResponse;
@@ -36,11 +37,11 @@ public class LeenkController {
 
     @PostMapping
     @Operation(summary = "링크(모집글) 작성 API")
-    public CommonResponse<Void> uploadLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
-                                            @RequestBody @Valid LeenkUploadRequest request) {
-        leenkUsecase.uploadLeenk(userId, request);
+    public CommonResponse<LeenkCreateResponse> uploadLeenk(@Parameter(hidden = true) @CurrentUserId Long userId,
+                                                           @RequestBody @Valid LeenkUploadRequest request) {
+        LeenkCreateResponse response = leenkUsecase.uploadLeenk(userId, request);
 
-        return CommonResponse.success(ResponseCode.UPLOAD_LEENK);
+        return CommonResponse.success(ResponseCode.UPLOAD_LEENK, response);
     }
 
     @PostMapping("/{leenkId}/participant")


### PR DESCRIPTION
## Related issue 🛠
- closed #60 

## 작업 내용 💻

- [x] 링크 상세조회에 응답 `dto`에 링크 상태 필드를 추가해서 반환
- [x] 링크 생성시, 새로 생성된 링크 `id` 포함시켜서 함께 반환

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- `leenk` API들 연결 과정에서 프론트분들 요구사항 맞춰 자잘한 내용들 수정했습니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 링크 업로드 API가 생성된 링크 ID를 포함한 본문 응답을 반환합니다. 클라이언트는 업로드 직후 ID를 활용해 상세 조회, 공유 등 후속 작업을 수행할 수 있습니다.
  - 링크 상세 응답에 상태(status) 필드가 추가되었습니다(예: RECRUITING). 화면 표시 및 필터링에 활용할 수 있습니다.
  - 변경된 응답 스키마가 API 문서에 반영되었습니다. 업로드 성공 응답의 페이로드 구조가 바뀌므로 클라이언트 파싱 로직을 업데이트하세요.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->