### PR TITLE
LNK-BE-30 참여자 퇴장 시 방장 알림

### DIFF
--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -350,5 +350,7 @@ public class LeenkUsecase {
         leenkParticipantsDeleteService.delete(participant);
 
         leenk.decreaseCurrentParticipants();
+
+        leenkNotificationUsecase.saveLeenkLeftNotification(leenk, user);
     }
 }

--- a/src/main/java/leets/leenk/domain/notification/application/mapper/LeenkNotificationMapper.java
+++ b/src/main/java/leets/leenk/domain/notification/application/mapper/LeenkNotificationMapper.java
@@ -159,4 +159,24 @@ public class LeenkNotificationMapper {
                 .build();
     }
 
+    public Notification toLeenkLeftNotification(Leenk leenk, User leftUser) {
+        return Notification.builder()
+                .userId(leenk.getAuthor().getId())
+                .notificationType(NotificationType.LEENK_LEFT)
+                .isRead(Boolean.FALSE)
+                .content(toLeenkLeftNotificationContent(leenk, leftUser))
+                .build();
+    }
+
+    private LeenkLeftNotificationContent toLeenkLeftNotificationContent(Leenk leenk, User leftUser) {
+        return LeenkLeftNotificationContent.builder()
+                .leenkId(leenk.getId())
+                .leenkTitle(leenk.getTitle())
+                .title(NotificationType.LEENK_LEFT.getTitle())
+                .body(NotificationType.LEENK_LEFT.getContent())
+                .leftUserId(leftUser.getId())
+                .leftUserName(leftUser.getName())
+                .build();
+    }
+
 }

--- a/src/main/java/leets/leenk/domain/notification/application/usecase/LeenkNotificationUsecase.java
+++ b/src/main/java/leets/leenk/domain/notification/application/usecase/LeenkNotificationUsecase.java
@@ -142,6 +142,28 @@ public class LeenkNotificationUsecase {
         publishLeenkStatusNotificationIfEnabled(notification, author, leenk, TitlePosition.SUFFIX);
     }
 
+    @Transactional
+    public void saveLeenkLeftNotification(Leenk leenk, User leftUser) {
+        User author = leenk.getAuthor();
+
+        Notification notification = leenkNotificationMapper.toLeenkLeftNotification(leenk, leftUser);
+        notificationSaveService.save(notification);
+
+        if (author.getFcmToken() == null) {
+            return;
+        }
+        try {
+            UserSetting userSetting = userSettingGetService.findByUser(author);
+            if (userSetting.isLeenkStatusNotify()) {
+                eventPublisher.publishEvent(sqsMessageEventMapper.fromLeenkLeft(notification,
+                        author.getFcmToken(), leenk.getId(), leftUser));
+            }
+        } catch (Exception e) {
+            log.warn("Failed to publish Leenk notification for user: {}, leenk: {}",
+                    author.getId(), leenk.getId(), e);
+        }
+    }
+
     private void publishLeenkStatusNotificationIfEnabled(Notification notification, User user, Leenk leenk,
                                                          TitlePosition titlePosition) {
         if (user.getFcmToken() == null) {

--- a/src/main/java/leets/leenk/domain/notification/domain/entity/NotificationContent.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/entity/NotificationContent.java
@@ -27,7 +27,8 @@ import lombok.experimental.SuperBuilder;
         @JsonSubTypes.Type(value = NewLeenkParticipantNotificationContent.class, name = "NEW_LEENK_PARTICIPANT"),
         @JsonSubTypes.Type(value = LeenkStartingSoonNotificationContent.class, name = "LEENK_STARTING_SOON"),
         @JsonSubTypes.Type(value = LeenkFinishedNotificationContent.class, name = "LEENK_FINISHED"),
-        @JsonSubTypes.Type(value = LeenkStartedHostReminderNotificationContent.class, name = "LEENK_STARTED_HOST_REMINDER")
+        @JsonSubTypes.Type(value = LeenkStartedHostReminderNotificationContent.class, name = "LEENK_STARTED_HOST_REMINDER"),
+        @JsonSubTypes.Type(value = LeenkLeftNotificationContent.class, name = "LEENK_LEFT")
 })
 public class NotificationContent {
 

--- a/src/main/java/leets/leenk/domain/notification/domain/entity/enums/NotificationType.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/entity/enums/NotificationType.java
@@ -16,6 +16,7 @@ public enum NotificationType {
     LEENK_STARTING_SOON("Leenk", " 시작 30분 전이야", "leenks"),
     LEENK_FINISHED("Leenk", "모임이 끝났어. 후기 쓰러 가볼까?", "leenks"),
     LEENK_STARTED_HOST_REMINDER("Leenk", "모임이 시작됐어! 모집을 종료할까?", "leenks"),
+    LEENK_LEFT("Leenk", "이 모임에서 나갔어", "leenks"),
 
     // Feed
     FEED_TAG("Leenk", "이 나를 함께한 사람에 추가했어", "feeds"),

--- a/src/main/java/leets/leenk/domain/notification/domain/entity/leenkContent/LeenkLeftNotificationContent.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/entity/leenkContent/LeenkLeftNotificationContent.java
@@ -1,0 +1,17 @@
+package leets.leenk.domain.notification.domain.entity.leenkContent;
+
+import leets.leenk.domain.notification.domain.entity.NotificationContent;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@NoArgsConstructor
+@Getter
+public class LeenkLeftNotificationContent extends NotificationContent {
+    private Long leenkId;
+    private String leenkTitle;
+    private Long leftUserId;
+    private String leftUserName;
+
+}

--- a/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
+++ b/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
@@ -3,6 +3,7 @@ package leets.leenk.global.sqs.application.mapper;
 import leets.leenk.domain.leenk.domain.entity.Leenk;
 import leets.leenk.domain.notification.domain.entity.enums.NotificationType;
 import leets.leenk.domain.notification.domain.entity.enums.TitlePosition;
+import leets.leenk.domain.user.domain.entity.User;
 import org.springframework.stereotype.Component;
 
 import leets.leenk.domain.notification.domain.entity.feedContent.FeedFirstReactionDetail;
@@ -72,6 +73,16 @@ public class SqsMessageEventMapper {
         return SqsMessageEvent.builder()
                 .title(notification.getContent().getTitle())
                 .content(body)
+                .fcmToken(fcmToken)
+                .path(notification.getNotificationType().getPath())
+                .id(id)
+                .build();
+    }
+
+    public SqsMessageEvent fromLeenkLeft(Notification notification, String fcmToken, Long id, User leftUser) {
+        return SqsMessageEvent.builder()
+                .title(notification.getContent().getTitle())
+                .content("[" + leftUser.getName() + "]" + notification.getContent().getBody())
                 .fcmToken(fcmToken)
                 .path(notification.getNotificationType().getPath())
                 .id(id)


### PR DESCRIPTION
- 방장에게만 알림

## Related issue 🛠
- closed #64 

## 작업 내용 💻

- 참여자 퇴장 시 방장에게 알림

## 스크린샷 📷

- 조회했을 시 결과
```json
{
    "code": 1300,
    "message": "알림 조회에 성공했습니다.",
    "data": {
        "notificationResponses": [
            {
                "id": "68ada4c5caf62118429b4cd0",
                "userId": 1,
                "notificationType": "LEENK_LEFT",
                "path": "leenks",
                "isRead": false,
                "content": {
                    "title": "Leenk",
                    "body": "이 모임에서 나갔어",
                    "leenkId": 59,
                    "leenkTitle": "링크 제목",
                    "leftUserId": 2,
                    "leftUserName": "Bob"
                },
                "updateDate": "2025-08-26T21:12:53.841"
            },
````

- 푸시 알림 로그
```
"notification": {
        "body": "[Bob]이 모임에서 나갔어",
        "title": "Leenk"
    },
````

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- 다음 PR에서 리팩토링 예정
  - ```publishLeenkStatusNotificationIfEnabled()```와 현재 작성한 알림 발송 부분이 겹쳐서 다음 PR에서 리팩토링할 예정입니다



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 모임 떠남 알림 추가: 참가자가 모임(Leenk)을 나가면 모임 작성자가 알림을 받습니다.
  * 알림에는 모임 제목과 떠난 사용자의 이름이 포함되며, 알림함에 미읽음으로 표시됩니다.
  * 푸시 알림 지원: 작성자가 푸시 수신을 켜고 FCM 토큰이 있는 경우 즉시 푸시로도 전달됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->