### PR TITLE
LNK-BE-32 푸시 알림 모임 이름 길이 제한 추가

### DIFF
--- a/src/main/java/leets/leenk/domain/notification/domain/entity/enums/NotificationType.java
+++ b/src/main/java/leets/leenk/domain/notification/domain/entity/enums/NotificationType.java
@@ -11,7 +11,7 @@ public enum NotificationType {
     NEW_LEENK("Leenk", "새로운 모임을 확인해 봐", "leenks"),
     LEENK_JOIN_COMPLETED("Leenk", "에 참여했어", "leenks"),
     NEW_LEENK_PARTICIPANT("Leenk", "에 새로운 참여자가 들어왔어", "leenks"),
-    KICKED_FROM_LEENK("Leenk", "모임에서 내보내졌어.", "leenks"),
+    KICKED_FROM_LEENK("Leenk", "모임에서 내보내졌어", "leenks"),
     LEENK_CLOSED("Leenk", "의 모집이 종료됐어\n모임원들을 확인해 봐!", "leenks"),
     LEENK_STARTING_SOON("Leenk", " 시작 30분 전이야", "leenks"),
     LEENK_FINISHED("Leenk", "모임이 끝났어. 후기 쓰러 가볼까?", "leenks"),

--- a/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
+++ b/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
@@ -61,7 +61,12 @@ public class SqsMessageEventMapper {
 	public SqsMessageEvent fromNotificationWithLeenk(Notification notification, String fcmToken, Leenk leenk,
                                                      TitlePosition position, Long id) {
         String body;
-        String leenkTitleFormatted = "[" + leenk.getTitle() + "]";
+
+        int limit = 6;
+        String title = leenk.getTitle();
+        String leenkTitleFormatted = String.format("[%s]",
+                title.length() > limit ? title.substring(0, limit) + "..." : title);
+
         String notificationBody = notification.getContent().getBody();
 
         if (position == TitlePosition.PREFIX) {

--- a/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
+++ b/src/main/java/leets/leenk/global/sqs/application/mapper/SqsMessageEventMapper.java
@@ -64,15 +64,15 @@ public class SqsMessageEventMapper {
 
         int limit = 6;
         String title = leenk.getTitle();
-        String leenkTitleFormatted = String.format("[%s]",
+        String leenkTitle = String.format("[%s]",
                 title.length() > limit ? title.substring(0, limit) + "..." : title);
 
         String notificationBody = notification.getContent().getBody();
 
         if (position == TitlePosition.PREFIX) {
-            body = leenkTitleFormatted + notificationBody;
+            body = leenkTitle + notificationBody;
         } else {
-            body = notificationBody + "\n" + leenkTitleFormatted;
+            body = notificationBody + "\n" + leenkTitle;
         }
 
         return SqsMessageEvent.builder()


### PR DESCRIPTION
## Related issue 🛠
- closed #68 

## 작업 내용 💻

- 푸시 알림 메시지에 모임 이름을 포함할 때, 모임 이름이 공백 포함 6글자를 초과하면 뒷부분을 없애고 `...`을 추가하도록 처리
- 추방 당한 경우의 알림 메세지를 ```모임에서 내보내졌어```로 마지막 ```.``` 제

## 스크린샷 📷

- 푸시 알림 로그
<img width="706" height="45" alt="image" src="https://github.com/user-attachments/assets/ed5bd0b2-57c2-4c24-8a72-27138b367602" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- x



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 알림 본문에 표시되는 모임 제목을 대괄호로 감싸고 최대 6자만 노출하며, 초과 시 "..."으로 축약해 모바일·작은 화면에서 가독성을 향상했습니다. 접두·후행 위치 모두 동일 형식으로 적용됩니다.

- Style
  - "모임에서 내보내졌어." 문구의 끝 마침표를 제거해("모임에서 내보내졌어") 알림 문장 스타일을 일관화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->