### PR TITLE
[LNK-19] Leenk 참여한 링크 종료 알림 최초 1회만 발송되도록 수정

### DIFF
--- a/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkRepository.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/repository/LeenkRepository.java
@@ -19,9 +19,6 @@ public interface LeenkRepository extends JpaRepository<Leenk, Long> {
     List<Leenk> findAllByStatusInAndStartTimeLessThanEqual(List<LeenkStatus> statuses,
                                                                                        LocalDateTime startTime);
 
-    List<Leenk> findAllByStatusAndStartTimeLessThanEqual(LeenkStatus status,
-                                                                                     LocalDateTime startTime);
-
     List<Leenk> findAllByStatusAndStartTimeGreaterThanAndStartTimeLessThanEqual(LeenkStatus status, LocalDateTime startTimeAfter,
                                                    LocalDateTime startTimeBefore);
 

--- a/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkGetService.java
+++ b/src/main/java/leets/leenk/domain/leenk/domain/service/LeenkGetService.java
@@ -55,8 +55,8 @@ public class LeenkGetService {
     }
 
     public List<Leenk> findUnnotifiedFinishedLeenks(LocalDateTime now) {
-        return leenkRepository.findAllByStatusAndStartTimeLessThanEqual(
-                LeenkStatus.FINISHED, now.minusHours(1));
+        return leenkRepository.findAllByStatusAndStartTimeGreaterThanAndStartTimeLessThanEqual(
+                LeenkStatus.FINISHED, now.minusHours(25), now.minusHours(1));
     }
 
     public List<Leenk> findOverdueRecruitingLeenksToNotify(LocalDateTime now) {


### PR DESCRIPTION
## Related issue 🛠
- x

## 작업 내용 💻

- 매일 23시에 실행되는 스케줄러에서 링크 종류 알림이 최초 1회만 발송되도록 수정
- 알림 발송 대상의 `startTime` 범위를 (now-25h, now-1h]로 변경


## 스크린샷 📷

- x

## 같이 얘기해보고 싶은 내용이 있다면 작성 📢

- x



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 미완료 작업 알림 감지 시간 범위를 확장했습니다. 이제 더 넓은 시간대의 미완료 작업을 정확하게 식별할 수 있습니다.

* **리팩토링**
  * 내부 데이터 조회 로직을 최적화하여 불필요한 쿼리 메서드를 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->