### PR TITLE
[LNK-33] 이미지 리사이징 로직 수정

### DIFF
--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -16,11 +16,10 @@ import leets.leenk.domain.feed.domain.entity.LinkedUser;
 import leets.leenk.domain.feed.domain.entity.Reaction;
 import leets.leenk.domain.feed.domain.service.*;
 import leets.leenk.domain.feed.domain.service.dto.FeedNavigationResult;
+import leets.leenk.domain.media.application.dto.request.FeedMediaRequest;
 import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
-import leets.leenk.domain.media.domain.service.MediaDeleteService;
-import leets.leenk.domain.media.domain.service.MediaGetService;
-import leets.leenk.domain.media.domain.service.MediaSaveService;
+import leets.leenk.domain.media.domain.service.*;
 import leets.leenk.domain.notification.application.usecase.FeedNotificationUsecase;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.entity.UserBlock;
@@ -58,6 +57,8 @@ public class FeedUsecase {
     private final MediaGetService mediaGetService;
     private final MediaSaveService mediaSaveService;
     private final MediaDeleteService mediaDeleteService;
+    private final MediaUpdateService mediaUpdateService;
+    private final MediaS3Service mediaS3Service;
 
     private final LinkedUserGetService linkedUserGetService;
     private final LinkedUserSaveService linkedUserSaveService;
@@ -181,6 +182,11 @@ public class FeedUsecase {
                 .toList();
         mediaSaveService.saveAll(medias);
 
+        medias.forEach(media -> {
+            String newMediaUrl = mediaS3Service.moveToOriginals(media.getMediaUrl());
+            mediaUpdateService.updateMediaUrl(media, newMediaUrl);
+        });
+
         List<LinkedUser> linkedUsers = getLinkedUsers(author, request.userIds(), feed);
         linkedUserSaveService.saveAll(linkedUsers);
 
@@ -247,7 +253,15 @@ public class FeedUsecase {
         if (request.media() != null) {
             mediaDeleteService.deleteAllByFeed(feed);
             List<Media> newMedias = request.media().stream()
-                    .map(mediaRequest -> mediaMapper.toMedia(feed, mediaRequest))
+                    .map(mediaRequest -> {
+                        String originalsUrl = mediaS3Service.moveToOriginals(mediaRequest.mediaUrl());
+                        FeedMediaRequest updatedRequest = new FeedMediaRequest(
+                                mediaRequest.position(),
+                                originalsUrl,
+                                mediaRequest.mediaType()
+                        );
+                        return mediaMapper.toMedia(feed, updatedRequest);
+                    })
                     .toList();
             mediaSaveService.saveAll(newMedias);
         }

--- a/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
+++ b/src/main/java/leets/leenk/domain/feed/application/usecase/FeedUsecase.java
@@ -253,17 +253,14 @@ public class FeedUsecase {
         if (request.media() != null) {
             mediaDeleteService.deleteAllByFeed(feed);
             List<Media> newMedias = request.media().stream()
-                    .map(mediaRequest -> {
-                        String originalsUrl = mediaS3Service.moveToOriginals(mediaRequest.mediaUrl());
-                        FeedMediaRequest updatedRequest = new FeedMediaRequest(
-                                mediaRequest.position(),
-                                originalsUrl,
-                                mediaRequest.mediaType()
-                        );
-                        return mediaMapper.toMedia(feed, updatedRequest);
-                    })
+                    .map(mediaRequest -> mediaMapper.toMedia(feed, mediaRequest))
                     .toList();
             mediaSaveService.saveAll(newMedias);
+
+            newMedias.forEach(media -> {
+                String originalsUrl = mediaS3Service.moveToOriginals(media.getMediaUrl());
+                mediaUpdateService.updateMediaUrl(media, originalsUrl);
+            });
         }
 
         if (request.userIds() != null) {

--- a/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
+++ b/src/main/java/leets/leenk/domain/leenk/application/usecase/LeenkUsecase.java
@@ -39,9 +39,7 @@ import leets.leenk.domain.leenk.domain.service.LeenkUpdateService;
 import leets.leenk.domain.leenk.domain.service.LocationSaveService;
 import leets.leenk.domain.media.application.mapper.MediaMapper;
 import leets.leenk.domain.media.domain.entity.Media;
-import leets.leenk.domain.media.domain.service.MediaDeleteService;
-import leets.leenk.domain.media.domain.service.MediaGetService;
-import leets.leenk.domain.media.domain.service.MediaSaveService;
+import leets.leenk.domain.media.domain.service.*;
 import leets.leenk.domain.notification.application.usecase.LeenkNotificationUsecase;
 import leets.leenk.domain.user.domain.entity.User;
 import leets.leenk.domain.user.domain.service.NotionDatabaseService;
@@ -75,6 +73,8 @@ public class LeenkUsecase {
     private final MediaSaveService mediaSaveService;
     private final MediaGetService mediaGetService;
     private final MediaDeleteService mediaDeleteService;
+    private final MediaUpdateService mediaUpdateService;
+    private final MediaS3Service mediaS3Service;
 
     private final UserGetService userGetService;
     private final SlackWebhookService slackWebhookService;
@@ -105,6 +105,9 @@ public class LeenkUsecase {
                 .ifPresent(url -> {
                     Media media = mediaMapper.toMedia(leenk, url);
                     mediaSaveService.save(media);
+
+                    String originalsUrl = mediaS3Service.moveToOriginals(media.getMediaUrl());
+                    mediaUpdateService.updateMediaUrl(media, originalsUrl);
                 });
 
         leenkNotificationUsecase.saveNewLeenkNotification(leenk);
@@ -137,10 +140,14 @@ public class LeenkUsecase {
             }
         } else {
             if (media != null) {
-                media.updateMediaUrl(newUrl);
+                String originalsUrl = mediaS3Service.moveToOriginals(newUrl);
+                media.updateMediaUrl(originalsUrl);
             } else {
                 Media newMedia = mediaMapper.toMedia(leenk, newUrl);
                 mediaSaveService.save(newMedia);
+
+                String originalsUrl = mediaS3Service.moveToOriginals(newMedia.getMediaUrl());
+                newMedia.updateMediaUrl(originalsUrl);
             }
         }
     }

--- a/src/main/java/leets/leenk/domain/media/application/exception/ErrorCode.java
+++ b/src/main/java/leets/leenk/domain/media/application/exception/ErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode implements ErrorCodeInterface {
 
     MEDIA_NOT_FOUND(2500, HttpStatus.NOT_FOUND, "존재하지 않는 미디어입니다."),
-    MEDIA_UPDATE_FAILED(2501, HttpStatus.INTERNAL_SERVER_ERROR, "미디어 업데이트에 실패했습니다.");
+    MEDIA_UPDATE_FAILED(2501, HttpStatus.INTERNAL_SERVER_ERROR, "미디어 업데이트에 실패했습니다."),
+    S3_COPY_FAILED(2502, HttpStatus.INTERNAL_SERVER_ERROR, "파일 복사에 실패했습니다.");
 
     private final int code;
     private final HttpStatus status;

--- a/src/main/java/leets/leenk/domain/media/application/exception/S3CopyException.java
+++ b/src/main/java/leets/leenk/domain/media/application/exception/S3CopyException.java
@@ -1,0 +1,9 @@
+package leets.leenk.domain.media.application.exception;
+
+import leets.leenk.global.common.exception.BaseException;
+
+public class S3CopyException extends BaseException {
+    public S3CopyException() {
+        super(ErrorCode.S3_COPY_FAILED);
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/entity/Media.java
+++ b/src/main/java/leets/leenk/domain/media/domain/entity/Media.java
@@ -72,5 +72,4 @@ public class Media {
     public void updateThumbnailUrl(String thumbnailUrl) {
         this.thumbnailUrl = thumbnailUrl;
     }
-
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaS3Service.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaS3Service.java
@@ -1,0 +1,37 @@
+package leets.leenk.domain.media.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.net.URI;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MediaS3Service {
+
+    private final S3PresignedUrlService s3PresignedUrlService;
+
+    public String moveToOriginals(String tempUrl) {
+        if (tempUrl == null || tempUrl.isBlank()) {
+            return tempUrl;
+        }
+
+        if (tempUrl.contains("/originals/")) {
+            return tempUrl;
+        }
+
+        String tempKey = extractKeyFromUrl(tempUrl);
+        String originalsKey = tempKey.replace("temp/", "originals/");
+
+        s3PresignedUrlService.copyObject(tempKey, originalsKey);
+        s3PresignedUrlService.deleteObject(tempKey);
+
+        return s3PresignedUrlService.getUrl(originalsKey);
+    }
+
+    private String extractKeyFromUrl(String url) {
+        URI uri = URI.create(url);
+        return uri.getPath().substring(1);
+    }
+}

--- a/src/main/java/leets/leenk/domain/media/domain/service/MediaUpdateService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/MediaUpdateService.java
@@ -11,4 +11,8 @@ public class MediaUpdateService {
     public void update(Media media, String thumbnailUrl){
         media.updateThumbnailUrl(thumbnailUrl);
     }
+
+    public void updateMediaUrl(Media media, String mediaUrl){
+        media.updateMediaUrl(mediaUrl);
+    }
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
@@ -5,6 +5,9 @@ import leets.leenk.domain.media.domain.entity.enums.DomainType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -21,8 +24,13 @@ public class S3PresignedUrlService {
 
     private final S3Presigner s3Presigner;
 
+    private final S3Client s3Client;
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
 
 
     public List<MediaUrlResponse> generateUrlList(DomainType domainType, List<String> fileNames) {
@@ -61,8 +69,32 @@ public class S3PresignedUrlService {
         String typePath = domainType.name().toLowerCase();
         String prefix = (index == 0) ? "thumbnail_" : "";
 
-        return String.format("originals/%s/%s%s", typePath, prefix, filename);
+        return String.format("temp/%s/%s%s", typePath, prefix, filename);
     }
 
+    public void copyObject(String sourceKey, String destinationKey) {
+        CopyObjectRequest copyRequest = CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(sourceKey)
+                .destinationBucket(bucket)
+                .destinationKey(destinationKey)
+                .build();
+
+        s3Client.copyObject(copyRequest);
+    }
+
+    public void deleteObject(String key) {
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+    }
+
+    public String getUrl(String key) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucket, region, key);
+    }
 
 }

--- a/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
+++ b/src/main/java/leets/leenk/domain/media/domain/service/S3PresignedUrlService.java
@@ -1,10 +1,12 @@
 package leets.leenk.domain.media.domain.service;
 
 import leets.leenk.domain.media.application.dto.response.MediaUrlResponse;
+import leets.leenk.domain.media.application.exception.S3CopyException;
 import leets.leenk.domain.media.domain.entity.enums.DomainType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -73,14 +75,19 @@ public class S3PresignedUrlService {
     }
 
     public void copyObject(String sourceKey, String destinationKey) {
-        CopyObjectRequest copyRequest = CopyObjectRequest.builder()
-                .sourceBucket(bucket)
-                .sourceKey(sourceKey)
-                .destinationBucket(bucket)
-                .destinationKey(destinationKey)
-                .build();
+        try {
+            CopyObjectRequest copyRequest = CopyObjectRequest.builder()
+                    .sourceBucket(bucket)
+                    .sourceKey(sourceKey)
+                    .destinationBucket(bucket)
+                    .destinationKey(destinationKey)
+                    .build();
 
-        s3Client.copyObject(copyRequest);
+            s3Client.copyObject(copyRequest);
+
+        } catch (SdkException e) {
+            throw new S3CopyException();
+        }
     }
 
     public void deleteObject(String key) {

--- a/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
+++ b/src/main/java/leets/leenk/domain/user/application/usecase/UserUsecase.java
@@ -1,5 +1,6 @@
 package leets.leenk.domain.user.application.usecase;
 
+import leets.leenk.domain.media.domain.service.MediaS3Service;
 import leets.leenk.domain.user.application.dto.request.*;
 import leets.leenk.domain.user.application.dto.response.UserInfoResponse;
 import leets.leenk.domain.user.application.exception.SelfBlockNotAllowedException;
@@ -37,6 +38,8 @@ public class UserUsecase {
     private final UserBlockMapper userBlockMapper;
     private final UserBlockService userBlockService;
 
+    private final MediaS3Service mediaS3Service;
+
     @Transactional
     public void initialAgreement(long userId, AgreementRequest request) {
         User user = userGetService.findById(userId);
@@ -69,7 +72,8 @@ public class UserUsecase {
     public void updateProfileImage(long userId, ProfileImageRequest request) {
         User user = userGetService.findById(userId);
 
-        userUpdateService.updateProfileImage(user, request.profileImage());
+        String originalsUrl = mediaS3Service.moveToOriginals(request.profileImage());
+        userUpdateService.updateProfileImage(user, originalsUrl);
     }
 
     @Transactional

--- a/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
+++ b/src/main/java/leets/leenk/domain/user/domain/service/user/UserUpdateService.java
@@ -1,14 +1,19 @@
 package leets.leenk.domain.user.domain.service.user;
 
+import leets.leenk.domain.media.domain.service.MediaS3Service;
 import leets.leenk.domain.user.application.dto.request.AgreementRequest;
 import leets.leenk.domain.user.application.dto.request.RegisterRequest;
 import leets.leenk.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 
 @Service
+@RequiredArgsConstructor
 public class UserUpdateService {
+
+    private final MediaS3Service mediaS3Service;
 
     public void updateAgreement(User user, AgreementRequest request) {
         user.updateAgreement(request.termsService(), request.privacyPolicy());
@@ -22,7 +27,8 @@ public class UserUpdateService {
         }
 
         if (request.profileImage() != null) {
-            user.updateProfileImage(request.profileImage());
+            String originalsUrl = mediaS3Service.moveToOriginals(request.profileImage());
+            user.updateProfileImage(originalsUrl);
         }
 
         if(request.birthday() != null) {

--- a/src/main/java/leets/leenk/global/config/AwsS3Config.java
+++ b/src/main/java/leets/leenk/global/config/AwsS3Config.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
@@ -27,6 +28,16 @@ public class AwsS3Config {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
 
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, accessSecret);
+
+        return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();


### PR DESCRIPTION
## Related issue 🛠
- closed #

## 작업 내용 💻
- 기존 문제: DB 등록 전 S3 PUT 발생 시 Lambda 트리거가 먼저 실행됐었습니다.
- 해결방법: 미디어 업로드 및 수정 시 임시 S3 경로 → 원본 경로(temp -> originals) 로 바꾼 후 S3 copy DB 업데이트 로직 적용했습니다.
- 임시경로에 저장된 이미지는 원본 경로로 바뀌면 삭제됩니다.
- profile, feed, leenk 모든 미디어 처리 로직 변경했습니다.
- S3 copy 권한 추가했습니다.

## 스크린샷 📷
- 프로필 등록 / 수정
<img width="1265" height="396" alt="스크린샷 2025-11-18 145207" src="https://github.com/user-attachments/assets/9f3d7118-6ab6-4731-8c15-7c5756452517" />

- 링크 등록 / 수정
<img width="1207" height="404" alt="스크린샷 2025-11-18 150524" src="https://github.com/user-attachments/assets/af4fd885-2d5f-41a0-a6b1-f0086c9b20a1" />

- 피드 등록 / 수정
<img width="1138" height="235" alt="스크린샷 2025-11-18 012403" src="https://github.com/user-attachments/assets/91f60fd4-c0ac-4e03-b087-6893693f70bb" />


## 같이 얘기해보고 싶은 내용이 있다면 작성 📢
원래 DB 등록 전 Lambda에서 대기를 주는 방법을 고려했지만 
1. 실행 중 지속적인 비용 발생과 동시 실행 제한 점유
2. 재시도 시 같은 대기 시간이 반복되어 효율이 떨어짐
3. DB 반영 시점을 정확히 예측하기 어려워 적절한 대기 시간을 정하기 어려움
4. 타임아웃 위험도 존재

하여 임시 경로 방식을 적용했습니다.
혹시 더 나은 방법이나 개선 아이디어가 있다면 같이 논의해보고 싶습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 업로드된 미디어를 임시 저장소에서 원본 저장소로 자동 이동하는 흐름 추가
  * 이동 후 미디어 URL을 갱신하는 처리 도입
  * S3 복사/삭제 및 URL 반환 기능 추가

* **개선사항**
  * 피드/Leenk 업로드와 프로필 이미지 업데이트 시 미디어 처리 일관성 향상
  * S3 클라이언트 구성 추가 및 오류 식별을 위한 전용 예외 및 에러 코드 도입
<!-- end of auto-generated comment: release notes by coderabbit.ai -->